### PR TITLE
add Allen Sun to TOC contributor list

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -19,6 +19,7 @@ If you are interested in engaging in this way, we would encourage you to issue a
 List below is the official list of TOC contributors, in alphabetical order:
 
 * Alex Chircop, StorageOS (alex.chircop@storageos.com)
+* Allen Sun, Alibaba (allensun.shl@alibaba-inc.com)
 * Andy Santosa, Ebay (asantosa@ebay.com)
 * Ara	Pulido, Bitnami	(ara@bitnami.com)
 * Bassam Tabbara, Upbound	(bassam@upbound.io)


### PR DESCRIPTION
I present myself to be a TOC contributor from Alibaba to help evaluate potential projects and contribute to working groups under CNCF. Actually, @xiang90 is the official TOC contributor who is tasked with consulting internal experts and expressing a semi-official view on a given project. While I would help Xiang and other forces from community to make things better.

I have been contributing to CNCF and related eco-system projects for quite a long time. I am an active contributor to project docker, containerd, kubernetes, swarm and so on. And now, my team is dedicated to polish container runtime within project [pouchcontainer](https://github.com/alibaba/pouch) whose purpose is close to cloud native. I promise I can definitely embrace the community to contribute my efforts.

/cc @caniszczyk @dankohn 

Signed-off-by: Allen Sun <allensun.shl@alibaba-inc.com>