### PR TITLE
Add Ayrat Khayretdinov to TOC Contributors

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -22,6 +22,7 @@ List below is the official list of TOC contributors, in alphabetical order:
 * Allen Sun, Alibaba (allensun.shl@alibaba-inc.com)
 * Andy Santosa, Ebay (asantosa@ebay.com)
 * Ara	Pulido, Bitnami	(ara@bitnami.com)
+* Ayrat Khayretdinov (akhayertdinov@cloudops.com)
 * Bassam Tabbara, Upbound	(bassam@upbound.io)
 * Bob	Wise, Samsung SDS	(bob@bobsplanet.com)
 * Cathy	Zhang, Huawei (cathy.h.zhang@huawei.com)


### PR DESCRIPTION
I present myself to be a TOC contributor from CloudOps - to help evaluate potential projects and contribute to working groups under CNCF. CloudOps moto - “help company to own their destiny in the Cloud” is a strong supporter of adoption and maturity of CNCF projects.

As a CNCF Ambassador I’m involved in Kubernetes, Prometheus, Istio and CNCF community in general and contributing to CNCF and related open source projects for quite a while. In addition i’m representing Canadian CNCF community (~5000 members). Actively presenting and advocating CNCF projects at the meetups, conferences and technical meetings. Additionally, maintaining and supporting Canadian CNCF slack channel. Due to nature of my activity as a CNCF Ambassador and Cloud Architect I’m very familiar with ecosystem and companies working in Cloud Native space. 

/cc @caniszczyk @dankohn
Signed-off-by: Ayrat Khayretdinov 
