### PR TITLE
Add a requirement regarding security audits

### DIFF
--- a/process/graduation_criteria.adoc
+++ b/process/graduation_criteria.adoc
@@ -23,7 +23,7 @@ To graduate from sandbox or incubating status, or for a new project to join as a
 
  * Have committers from at least two organizations.
  * Have achieved and maintained a Core Infrastructure Initiative https://bestpractices.coreinfrastructure.org/[Best Practices Badge].
- * Have completed an independent and third party security audit with results published (i.e., https://github.com/envoyproxy/envoy#security-audit)
+ * Have completed an independent and third party security audit with results published of similar scope and quality as the following example (including critical vulnerabilities addressed): https://github.com/envoyproxy/envoy#security-audit
  * Adopt the CNCF https://github.com/cncf/foundation/blob/master/code-of-conduct.md[Code of Conduct].
  * Explicitly define a project governance and committer process. This preferably is laid out in a GOVERNANCE.md file and references an OWNERS.md file showing the current and emeritus committers.
  * Have a public list of project adopters for at least the primary repo (e.g., ADOPTERS.md or logos on the project website).

--- a/process/graduation_criteria.adoc
+++ b/process/graduation_criteria.adoc
@@ -23,7 +23,7 @@ To graduate from sandbox or incubating status, or for a new project to join as a
 
  * Have committers from at least two organizations.
  * Have achieved and maintained a Core Infrastructure Initiative https://bestpractices.coreinfrastructure.org/[Best Practices Badge].
- * Have completed an independent and third party security audit with results published of similar scope and quality as the following example (including critical vulnerabilities addressed): https://github.com/envoyproxy/envoy#security-audit
+ * Have completed an independent and third party security audit with results published of similar scope and quality as the following example (including critical vulnerabilities addressed): https://github.com/envoyproxy/envoy#security-audit and all critical vulnerabilities need to be addressed before graduation.
  * Adopt the CNCF https://github.com/cncf/foundation/blob/master/code-of-conduct.md[Code of Conduct].
  * Explicitly define a project governance and committer process. This preferably is laid out in a GOVERNANCE.md file and references an OWNERS.md file showing the current and emeritus committers.
  * Have a public list of project adopters for at least the primary repo (e.g., ADOPTERS.md or logos on the project website).

--- a/process/graduation_criteria.adoc
+++ b/process/graduation_criteria.adoc
@@ -1,4 +1,4 @@
-== CNCF Graduation Criteria v1.1
+== CNCF Graduation Criteria v1.2
 
 Every CNCF project has an associated maturity level. Proposed CNCF projects should state their preferred maturity level. A two-thirds supermajority is required for a project to be accepted as incubating or graduated. If there is not a supermajority of votes to enter as a graduated project, then any graduated votes are recounted as votes to enter as an incubating project. If there is not a supermajority of votes to enter as an incubating project, then any graduated or incubating votes are recounted as sponsorship to enter as an sandbox project. If there is not enough sponsorship to enter as an sandbox stage project, the project is rejected. This voting process is called fallback voting.
 
@@ -23,7 +23,9 @@ To graduate from sandbox or incubating status, or for a new project to join as a
 
  * Have committers from at least two organizations.
  * Have achieved and maintained a Core Infrastructure Initiative https://bestpractices.coreinfrastructure.org/[Best Practices Badge].
+ * Have completed an independent and third party security audit with results published (i.e., https://github.com/envoyproxy/envoy#security-audit)
  * Adopt the CNCF https://github.com/cncf/foundation/blob/master/code-of-conduct.md[Code of Conduct].
  * Explicitly define a project governance and committer process. This preferably is laid out in a GOVERNANCE.md file and references an OWNERS.md file showing the current and emeritus committers.
  * Have a public list of project adopters for at least the primary repo (e.g., ADOPTERS.md or logos on the project website).
  * Receive a supermajority vote from the TOC to move to graduation stage. Projects can attempt to move directly from sandbox to graduation, if they can demonstrate sufficient maturity. Projects can remain in an incubating state indefinitely, but they are normally expected to graduate within two years.
+


### PR DESCRIPTION
A part of achieving a CII Badge involves in setting up a security disclosure process, which is a great practice for all open source projects to have. However, not all security disclosure processes are tested so the TOC is considering the requirement moving forward to have CNCF projects go through a third party security audit which helps test the security disclosure process.

Some examples here:
https://github.com/envoyproxy/envoy#security-audit
https://coredns.io/2018/03/15/cure53-security-assessment/