### PR TITLE
Add Jun Du to TOC contributor

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -49,6 +49,7 @@ List below is the official list of TOC contributors, in alphabetical order:
 * Joseph Jacks, Independent	(jacks.joe@gmail.com)
 * Josh Bernstein, Dell (Joshua.Bernstein@dell.com)
 * Justin Cormack, Docker (justin.cormack@docker.com)
+* Jun Du, Huawei (dujun5@huawei.com)
 * Lachlan	Evenson, Microsoft (lachlan.evenson@microsoft.com)
 * Lee Calcote, SolarWinds (leecalcote@gmail.com)
 * Lei	Zhang, HyperHQ (harryzhang@zju.edu.cn)


### PR DESCRIPTION
I represent Huawei to help evaluate potential projects and contribute to working groups.

I have been contributing to CNCF and related eco-system since 2015 with my work on Kubernetes(and its subprojects), Istio, CNI plugins and etcd etc. And now, my group at Huawei is contributing to various CNCF areas including Networking, Strorage, Service Mesh, Orchestration, Serverless, etc..

/cc @caniszczyk @dankohn @quinton-hoole 
