### PR TITLE
Adding myself (Steven Dake) as a CNCF TOC contrib

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -63,6 +63,7 @@ List below is the official list of TOC contributors, in alphabetical order:
 * Randy	Abernethy, RX-M LLC (randy.abernethy@rx-m.com)
 * Rick Spencer, Bitnami	(rick@bitnamni.com)
 * Sarah Allen, Google (sarahallen@google.com)
+* Steven Dake, Cisco (stdake@cisco.com)
 * Tammy Butow, Gremlin (tammy@gremlin.com)
 * Timothy Chen, Hyperpilot (tim@hyperpilot.io)
 * Vasu Chandrasekhara, SAP SE (vasu.chandrasekhara@sap.com)


### PR DESCRIPTION
I have been working in the container ecosystem since the launch
of Docker. I also serve as an individually elected member of the
OpenStack foundation. My technical focus today is Istio (https://istio.io).

Lew Tucker (@cisco) has requested I liason between the CNCF TOC and
Cisco internal teams to present a "semi-offcial" view of Cisco's
position.