### PR TITLE
Add Jinming Yue to TOC contributors

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -45,6 +45,7 @@ List below is the official list of TOC contributors, in alphabetical order:
 * Gou	Rao, Portworx (gou@portworx.com)
 * Ian Crosby, Container Solutions (ian.crosby@container-solutions.com)
 * Jeyappragash JJ, Independent (pragashjj@gmail.com)
+* Jinming Yue, Caicloud (yuejinming@caicloud.io)
 * Joe Beda, Heptio (joe@heptio.com)
 * Jonghyuk Jong Choi, NCSoft (jongchoi@ncsoft.com)
 * Josef Adersberger, QAware (josef.adersberger@qaware.de)


### PR DESCRIPTION
I represent Caicloud to help evaluate potential projects and contribute to working groups.

I have been contributing to CNCF and related eco-system since 2015 with my work on  Kubernetes, Harbor, Istio etc. And now, my group at Caicloud is contributing to various CNCF areas including Orchestration, Service Mesh, Storage etc.

