### PR TITLE
CNCF SIGs Final Proposal

### DIFF
--- a/sigs/cncf-sigs.md
+++ b/sigs/cncf-sigs.md
@@ -23,23 +23,23 @@ Scale contributions by the CNCF technical and user community, while retaining in
 
 * Focus attention & resources on helping foster project maturity, systematically across CNCF projects.
 
-* Clarify relationship between projects, CNCF project staff, and community volunteers
+* Clarify relationship between projects, CNCF project staff, and community volunteers.
 
-* Engage more communities and create an on-ramp to effective TOC contribution & recognition
+* Engage more communities and create an on-ramp to effective TOC contribution & recognition.
 
 * Reduce some project workload on TOC while retaining executive control & tonal integrity with this elected body.
 
-* Avoid creating a platform for politics between vendors
+* Avoid creating a platform for politics between vendors.
 
 ## Introduction
 
 A CNCF SIG will oversee and coordinate the interests pertaining to a logical area of needs of end users and/or projects.  Examples of such areas include security, testing, observability, storage, networking, etc.  The area overseen by a SIG is typically met by a set of CNCF projects, and may also represent a cross-cutting feature group shared by several projects (like security and observability).  SIG’s are:
 
-* long lived groups that report to the Technical Oversight Committee.
+* long lived groups that report to the Technical Oversight Committee
 
 * led primarily by recognised experts in the relevant field(s), supported by other contributors
 
-CNCF SIGs are modelled on Kubernetes SIGS.  Differences are intended to be minimal to avoid confusion - unavoidable differences are described [here](https://docs.google.com/document/d/1oSGhx5Hw7Hs_qawYB46BvRSPh0ZvFoxvHx-NWaf5Nsc/edit?usp=sharing).
+CNCF SIGs are modelled on Kubernetes SIGs.  Differences are intended to be minimal to avoid confusion - unavoidable differences are described [here](https://docs.google.com/document/d/1oSGhx5Hw7Hs_qawYB46BvRSPh0ZvFoxvHx-NWaf5Nsc/edit?usp=sharing).
 
 ## Responsibilities & Empowerment of SIGs
 
@@ -49,7 +49,7 @@ The SIGs should strive to present the TOC with easily understandable and votable
 
 Key ideas here:
 
-* The TOC is the arbiter & editor and may always intervene and overrule 
+* The TOC is the arbiter & editor and may always intervene and overrule. 
 
 * The SIGs are the productive talent, and respected as such.
 
@@ -97,11 +97,11 @@ SIGs may choose to spawn focussed and time-limited working groups to achieve som
 
 #### SIG Charter:
 
-    * formally reviewed annually, and approved by the TOC.  The charter must clearly articulate:
+    * This is formally reviewed annually, and approved by the TOC.  The charter must clearly articulate:
 
-        * what is in and out of scope of the SIG
+        * what is in and out of scope of the SIG,
 
-        * whether and how it overlaps and interfaces with other CNCF SIG’s or other relevant groups.
+        * whether and how it overlaps and interfaces with other CNCF SIG’s or other relevant groups, and 
 
         * how it operates and is governed, and specifically whether and how it deviates from standard SIG operating guidelines provided by the TOC.  Deviation from these guidelines is discouraged, unless there are good and well-documented reasons for such divergence, approved by the TOC. 
 
@@ -109,9 +109,7 @@ See [Example Responsibilities of a CNCF SIG](https://docs.google.com/document/d/
 
 ## Operating Model
 
-*Important*
-
-*Each SIG is supported by a named member of the CNCF executive staff who is accountable for liaison with the CNCF Exec, plus communication and performance of the SIG, with quarterly and annual reporting to GB & TOC. *** **
+Important: Each SIG is supported by a named member of the CNCF executive staff who is accountable for liaison with the CNCF Executive Director, plus communication and performance of the SIG, with quarterly and annual reporting to Governing Board & TOC.
 
 As a starting point let’s be inspired by CNCF OSS Projects and by K8S SIGs.  That means minimal viable governance and community-based organisation.
 
@@ -119,13 +117,13 @@ As a starting point let’s be inspired by CNCF OSS Projects and by K8S SIGs.  T
 
 1. SIGs are formed by the TOC.  Initial SIGs are listed below, and will be adapted over time as required.  If members of the community believe that additional SIGs are desired, they should propose these to the TOC, with clear justification, and ideally volunteers to lead the SIG. The TOC wishes to have the smallest viable number of SIGs, and for all of them to be highly effective (as opposed to a "SIG sprawl" with large numbers of relatively ineffective SIGS).
 
-2. SIG has three co-chairs, who are TOC Contributors and recognised as unbiased experts in that area.
+2. SIG has three co-chairs, who are TOC Contributors, recognized as experts in that area, and for their ability to co-lead the SIG to produce the required unbiased outputs.
 
-3. SIG has one TOC liaison who is a voting member of the TOC acting as non-exec chair on occasions when TOC input is deemed necessary by the TOC or the SIG chairs
+3. SIG has one TOC liaison who is a voting member of the TOC acting as an additional non-executive chair on occasions when TOC input is deemed necessary by the TOC or the SIG chairs.
 
-4. SIG has multiple tech leads who are recognised as unbiased experts in the SIG area, and are recognised leaders of projects in the SIG’s area.  The reason for having separate chair and tech lead roles is to allow responsibility for primarily administrative functions to be separated from deep technical functions and associated time commitments and skill sets.  Where appropriate, an individual may perform both roles (see below).
+4. SIG has multiple tech leads who are recognized as (1) experts in the SIG area, (2) leaders of projects in the SIG’s area (3) demonstrating the ability to provide the balanced technical leadership required to produce the required unbiased outputs of the SIG. The reason for having separate chair and tech lead roles is to allow responsibility for primarily administrative functions to be separated from deep technical functions and associated time commitments and skill sets.  Where appropriate, an individual may perform both roles (see below).
 
-5. Thought and interest diversity is strongly encouraged within SIGs.  To this end, a supermajority (⅔ or more) of chairs or tech leads from a single group of companies, market segment, etc will be actively discouraged by the TOC.
+5. Thought and interest diversity is strongly encouraged within SIGs.  To this end, a supermajority (⅔ or more) of chairs or a supermajority of tech leads from a single group of companies, market segment, etc will be actively discouraged by the TOC.
 
 6. SIG members are self-declared, so that some SIG work is done by volunteers from the TOC Contributors and community.  To recognise members who make sustained  and valuable contributions to a SIG over time, SIG-defined and assigned roles may be created (e.g. scribe, training or documentation coordinator etc).  SIG’s should document what these roles and responsibilities are, and who performs them, and have them approved by SIG leads.
 
@@ -169,7 +167,7 @@ As a starting point let’s be inspired by CNCF OSS Projects and by K8S SIGs.  T
 
 * The TOC and Chairs nominate Tech leads
 
-* Tech leads are assigned following a majority vote of the TOC and SIG Chairs
+* Tech leads are assigned following a 2/3 majority vote of the TOC and a 2/3 majority vote of SIG Chairs
 
 * SIG Chairs and Tech Leads may be unassigned from the SIG at any time following a 2/3 majority vote of the TOC
 

--- a/sigs/cncf-sigs.md
+++ b/sigs/cncf-sigs.md
@@ -1,0 +1,251 @@
+# CNCF Special Interest Groups ("SIGs")
+
+Proposal by the CNCF TOC and Contributors
+Primary Authors: Alexis Richardson, Quinton Hoole
+November 2018 - January 2019
+
+Final Draft v1.0
+
+[[TOC]]
+
+## Overall Purpose
+
+Scale contributions by the CNCF technical and user community, while retaining integrity and increasing quality in support of our [mission](https://github.com/cncf/foundation/blob/master/charter.md#1-mission-of-the-cloud-native-computing-foundation). 
+
+## Specific Objectives
+
+* Strengthen the project ecosystem to meet the needs of end users and project contributors.
+
+* Identify gaps in the CNCF project portfolio.  Find and attract projects to fill these gaps.
+
+* Educate and inform users with unbiased, effective, and practically useful information.
+
+* Focus attention & resources on helping foster project maturity, systematically across CNCF projects.
+
+* Clarify relationship between projects, CNCF project staff, and community volunteers
+
+* Engage more communities and create an on-ramp to effective TOC contribution & recognition
+
+* Reduce some project workload on TOC while retaining executive control & tonal integrity with this elected body.
+
+* Avoid creating a platform for politics between vendors
+
+## Introduction
+
+A CNCF SIG will oversee and coordinate the interests pertaining to a logical area of needs of end users and/or projects.  Examples of such areas include security, testing, observability, storage, networking, etc.  The area overseen by a SIG is typically met by a set of CNCF projects, and may also represent a cross-cutting feature group shared by several projects (like security and observability).  SIG’s are:
+
+* long lived groups that report to the Technical Oversight Committee.
+
+* led primarily by recognised experts in the relevant field(s), supported by other contributors
+
+CNCF SIGs are modelled on Kubernetes SIGS.  Differences are intended to be minimal to avoid confusion - unavoidable differences are described [here](https://docs.google.com/document/d/1oSGhx5Hw7Hs_qawYB46BvRSPh0ZvFoxvHx-NWaf5Nsc/edit?usp=sharing).
+
+## Responsibilities & Empowerment of SIGs
+
+It is the desire of the TOC that the CNCF SIGs, under guidance from the TOC, provide high-quality technical expertise, unbiased information and proactive leadership within their category.  The TOC makes use of this input to act as an informed and effective executive board to select and promote appropriate CNCF projects and practices, and to disseminate high quality information to end users and the cloud-native community in general.  SIGs explicitly have no direct authority over CNCF projects. In particular, the creation of CNCF SIG’s does not change the existing, successfully practiced [charter](https://github.com/cncf/foundation/blob/master/charter.md) goal that "Projects.. will be ‘lightly’ subject to the Technical Oversight Committee". 
+
+The SIGs should strive to present the TOC with easily understandable and votable "propositions", each of which is supported by clear written evidence.  A proposition may be “to approve this project for incubation based on this [written ](https://github.com/cncf/toc/blob/master/process/due-diligence-guidelines.md)[due diligence](https://github.com/cncf/toc/blob/master/process/due-diligence-guidelines.md)[ investigation](https://github.com/cncf/toc/blob/master/process/due-diligence-guidelines.md)”, or “to approve this landscape document based on these clear goals and evidence that it achieves them”.  It is of utmost importance that the information and proposals provided to the TOC by SIGs be highly accurate and unbiased, driven by the goal to improve the CNCF as a whole, rather than benefit one project or company over another.  We believe that the rising tide lifts all boats, and that is our goal.
+
+Key ideas here:
+
+* The TOC is the arbiter & editor and may always intervene and overrule 
+
+* The SIGs are the productive talent, and respected as such.
+
+SIGs may choose to spawn focussed and time-limited working groups to achieve some of their responsibilities (for example, to produce a specific educational white paper, or portfolio gap analysis report).  Working groups should have a clearly documented charter, timeline (typically a few quarters at most), and set of deliverables. Once the timeline has elapsed, or the deliverables delivered, the working group dissolves, or is explicitly re-chartered.
+
+### Specific SIG Responsibilities 
+
+#### Project Handling:
+
+    * Understand and document a high level roadmap of projects within this space, including CNCF and non-CNCF projects. Identify gaps in project landscape.
+
+    * For projects that fall within the CNCF, perform health checks.
+
+    * Perform discovery of and outreach to candidate projects
+
+    * Help candidate projects prepare for presentation to the TOC
+
+    * Every CNCF project will be assigned to one suitable SIG by the TOC.
+
+#### End User Education (Outbound Communication)
+
+    * Provide up-to-date, high quality, unbiased and easy-to-consume material to help end users to understand and effectively adopt cloud-native technologies and practises within the SIG’s area, for example:
+
+        * White papers, presentations, videos, or other forms of training clarifying terminology, comparisons of different approaches, available projects or products, common or recommended practises, trends, illustrative successes and failures, etc.
+
+        * As far as possible, information should be based on research and fact gathering, rather than pure marketing or speculation.  
+
+#### End User Input Gathering (Inbound Communication)
+
+    * Gather useful end user input and feedback regarding expectations, pain points, primary use cases etc.
+
+    * Compile this into easily consumable reports and/or presentations to assist projects with feature design, prioritization, UX etc.
+
+#### Community Enablement
+
+    * SIGs are open organizations with meetings, meeting agendas and notes, mailing lists, and other communications in the open
+
+    * The mailing list, SIG meeting calendar, and other communication documents of the SIG will be openly published and maintained
+
+#### As Trusted Expert Advisors to the TOC
+
+    * Perform technical due diligence on new and graduating projects, and advise TOC on findings.
+
+    * Be involved with, or periodically check in with projects in their area, and advise TOC on health, status and proposed actions (if any) as necessary or on request.
+
+#### SIG Charter:
+
+    * formally reviewed annually, and approved by the TOC.  The charter must clearly articulate:
+
+        * what is in and out of scope of the SIG
+
+        * whether and how it overlaps and interfaces with other CNCF SIG’s or other relevant groups.
+
+        * how it operates and is governed, and specifically whether and how it deviates from standard SIG operating guidelines provided by the TOC.  Deviation from these guidelines is discouraged, unless there are good and well-documented reasons for such divergence, approved by the TOC. 
+
+See [Example Responsibilities of a CNCF SIG](https://docs.google.com/document/d/1L9dJl5aBFnN5KEf82J689FY0UtnUawnt9ooCq8SkO_w/edit?usp=sharing).
+
+## Operating Model
+
+*Important*
+
+*Each SIG is supported by a named member of the CNCF executive staff who is accountable for liaison with the CNCF Exec, plus communication and performance of the SIG, with quarterly and annual reporting to GB & TOC. *** **
+
+As a starting point let’s be inspired by CNCF OSS Projects and by K8S SIGs.  That means minimal viable governance and community-based organisation.
+
+### SIG Formation, Leadership and Membership Composition
+
+1. SIGs are formed by the TOC.  Initial SIGs are listed below, and will be adapted over time as required.  If members of the community believe that additional SIGs are desired, they should propose these to the TOC, with clear justification, and ideally volunteers to lead the SIG. The TOC wishes to have the smallest viable number of SIGs, and for all of them to be highly effective (as opposed to a "SIG sprawl" with large numbers of relatively ineffective SIGS).
+
+2. SIG has three co-chairs, who are TOC Contributors and recognised as unbiased experts in that area.
+
+3. SIG has one TOC liaison who is a voting member of the TOC acting as non-exec chair on occasions when TOC input is deemed necessary by the TOC or the SIG chairs
+
+4. SIG has multiple tech leads who are recognised as unbiased experts in the SIG area, and are recognised leaders of projects in the SIG’s area.  The reason for having separate chair and tech lead roles is to allow responsibility for primarily administrative functions to be separated from deep technical functions and associated time commitments and skill sets.  Where appropriate, an individual may perform both roles (see below).
+
+5. Thought and interest diversity is strongly encouraged within SIGs.  To this end, a supermajority (⅔ or more) of chairs or tech leads from a single group of companies, market segment, etc will be actively discouraged by the TOC.
+
+6. SIG members are self-declared, so that some SIG work is done by volunteers from the TOC Contributors and community.  To recognise members who make sustained  and valuable contributions to a SIG over time, SIG-defined and assigned roles may be created (e.g. scribe, training or documentation coordinator etc).  SIG’s should document what these roles and responsibilities are, and who performs them, and have them approved by SIG leads.
+
+### SIG Member Roles
+
+#### Chair
+
+* Three chairs where the active chair rotates each week/fortnight/month.
+
+* Primarily performs administrative functions including collecting and compiling topics for the (bi)weekly agenda, chairing the meeting, ensuring that quality meeting minutes are published, and follow-up actions tracked and resolved.
+
+* A chair role may be held and performed by a tech lead, in cases where one person has the time and ability to perform both roles to the satisfaction of the TOC and SIG members.
+
+#### Tech Lead
+
+* Leads projects in the SIG’s area.
+
+* Has the time and ability to perform deep technical dives on projects.   Projects may include formal CNCF projects or other projects in the area covered by the SIG.
+
+#### Other named roles
+
+* Named and defined by the SIG (e.g. scribe, PR lead, docs/training lead, etc)
+
+* Approved by supermajority of the chairs.
+
+#### Other members
+
+* Self-declared
+
+* May either have no explicit roles or responsibilities, or formally assigned roles (see above).
+
+* May not create the impression that they have any authority or formal responsibilities in the SIG other than assigned roles.
+
+### Elections
+
+* The TOC nominates Chairs
+
+* Chairs are assigned following a 2/3 majority vote of the TOC
+
+* Terms last for 1 year but staggered such that at least 1 of the chairs is able to maintain continuity
+
+* The TOC and Chairs nominate Tech leads
+
+* Tech leads are assigned following a majority vote of the TOC and SIG Chairs
+
+* SIG Chairs and Tech Leads may be unassigned from the SIG at any time following a 2/3 majority vote of the TOC
+
+### Governance
+
+* All SIGs inherit and follow the CNCF TOC Operating Principles.
+
+* SIGs must have a documented governance process that encourages community participation and clear guidelines to avoid biased decision-making.  
+
+    * NOTE: aim here is to align with "minimal viable" model of the CNCF projects, and only have such governance as is needed, not anything too burdensome
+
+* They may grow a set of practices over time in the same way as an OSS Project, provided this is consistent with CNCF Operating Principles. 
+
+* As with CNCF Projects all exceptions and disputes are handled by TOC with CNCF Staff help
+
+### Budget & Resource
+
+* No formal systematic budget at this time, other than commitment of CNCF executive staff to provide named person as liaison point.
+
+* Just as CNCF Projects may have "help" offered by CNCF and may ask for things via the [ServiceDesk](https://github.com/cncf/servicedesk), the SIGs may do this.
+
+## Retirement
+
+* In the event that a SIG is unable to regularly establish quorum, or fulfill the responsibilities and/or regularly report to the TOC, the TOC will:
+
+    * Consider retiring the SIG after 3 months
+
+    * Must retire the SIG after 6 months
+
+* The TOC may, by means of a 2/3 majority vote, declare "no confidence" in the SIG.  In this event, the TOC may then vote to retire or reconstitute the SIG.
+
+## Initial SIGS
+
+To bootstrap the process, the TOC proposes the following SIGs, and projects assigned to each SIG. Clearly all of these SIG’s will not be fully-formed overnight or begin operating immediately, so the TOC itself will fulfill the duties of not-yet-formed SIG’s until they are.  We can however, fairly immediately, assign one voting member of the TOC as liason for each SIG, and prioritize the order of formation of the SIGs, starting immediately with the most pressing ones. 
+
+<table>
+  <tr>
+    <td>Name (to be finalised)</td>
+    <td>Area</td>
+    <td>Current CNCF Projects</td>
+  </tr>
+  <tr>
+    <td>Traffic</td>
+    <td>networking, service discovery, load balancing, service mesh, RPC, pubsub, etc.</td>
+    <td>Envoy, Linkerd, NATS, gRPC, CoreDNS, CNI</td>
+  </tr>
+  <tr>
+    <td>Observability</td>
+    <td>monitoring, logging, tracing, profiling, etc.
+</td>
+    <td>Prometheus, OpenTracing, Fluentd, Jaeger, Cortex, OpenMetrics, </td>
+  </tr>
+  <tr>
+    <td>Governance</td>
+    <td>security, authentication, authorization, auditing, policy enforcement, compliance, GDPR, cost management, etc</td>
+    <td>SPIFFE, SPIRE, Open Policy Agent, Notary, TUF,  Falco, </td>
+  </tr>
+  <tr>
+    <td>App Dev, Ops & Testing</td>
+    <td>PaaS, Serverless, Operators,... CI/CD,  Conformance, Chaos Eng, Scalability and Reliability measurement etc.</td>
+    <td>Helm, CloudEvents, Telepresence, Buildpacks, (CNCF CI)</td>
+  </tr>
+  <tr>
+    <td>Core and Applied Architectures</td>
+    <td>orchestration, scheduling, container runtimes, sandboxing technologies, packaging and distribution, specialized architectures thereof (e.g. Edge, IoT, Big Data, AI/ML, etc).</td>
+    <td>Kubernetes, containerd, rkt, Harbor, Dragonfly, Virtual Kubelet</td>
+  </tr>
+  <tr>
+    <td>Storage</td>
+    <td>Block and File Stores, Databases, Key-Value stores etc.</td>
+    <td>TiKV, etcd, Vitess, Rook</td>
+  </tr>
+</table>
+
+
+The TOC and CNCF Staff will draft an initial set of charters for the above, and solicit/elect suitable chairs.
+
+## Appendix A: Worked Example - CNCF Governance SIG
+
+See [separate document](https://docs.google.com/document/d/18ufx6TjPavfZubwrpyMwz6KkU-YA_aHaHmBBQkplnr0/edit?usp=sharing). 

--- a/sigs/cncf-sigs.md
+++ b/sigs/cncf-sigs.md
@@ -239,7 +239,7 @@ To bootstrap the process, the TOC proposes the following SIGs, and projects assi
   </tr>
   <tr>
     <td>Storage</td>
-    <td>Block and File Stores, Databases, Key-Value stores etc.</td>
+    <td>Block, File and Object Stores, Databases, Key-Value stores etc.</td>
     <td>TiKV, etcd, Vitess, Rook</td>
   </tr>
 </table>

--- a/sigs/cncf-sigs.md
+++ b/sigs/cncf-sigs.md
@@ -163,7 +163,7 @@ As a starting point let’s be inspired by CNCF OSS Projects and by K8S SIGs.  T
 
 * Chairs are assigned following a 2/3 majority vote of the TOC
 
-* Terms last for 1 year but staggered such that at least 1 of the chairs is able to maintain continuity
+* Terms last for 2 years but staggered such that at least 1 of the chairs is able to maintain continuity
 
 * The TOC and Chairs nominate Tech leads
 
@@ -228,7 +228,7 @@ To bootstrap the process, the TOC proposes the following SIGs, and projects assi
   <tr>
     <td>App Dev, Ops & Testing</td>
     <td>PaaS, Serverless, Operators,... CI/CD,  Conformance, Chaos Eng, Scalability and Reliability measurement etc.</td>
-    <td>Helm, CloudEvents, Telepresence, Buildpacks, (CNCF CI)</td>
+    <td>Helm, CloudEvents, Telepresence, Buildpacks</td>
   </tr>
   <tr>
     <td>Core and Applied Architectures</td>

--- a/sigs/cncf-sigs.md
+++ b/sigs/cncf-sigs.md
@@ -1,3 +1,4 @@
+
 # CNCF Special Interest Groups ("SIGs")
 
 Proposal by the CNCF TOC and Contributors


### PR DESCRIPTION
This is simply the doc below, which has been under heavy public development and review since early Dec 2018, converted to markdown so that it can be voted upon and merged.

As discussed in the related email thread, and on the TOC call today, precise SIG names, scope definitions and charters will be finalized while bootstrapping each SIG - the names in this doc should not considered final.

https://docs.google.com/document/d/1mt1LH1QJgwA91A6x-DEdjg4ZOXrOnxxc1d2xhq4Hq3I/edit#heading=h.cswy6dl41jv 


