### PR TITLE
Clarify accepted document types for TOC proposals

### DIFF
--- a/process/project_proposals.adoc
+++ b/process/project_proposals.adoc
@@ -1,7 +1,7 @@
-*CNCF Project Proposal Process v1.2*
+== CNCF Project Proposal Process v1.2
 
  . *Introduction*. This governance policy sets forth the proposal process for projects to be accepted into the Cloud Native Computing Foundation (“CNCF”). The process is the same for both existing projects which seek to move into the CNCF, and new projects to be formed within the CNCF.
- . *Project Proposal Requirements*. Projects must be proposed via https://github.com/cncf/toc/tree/master/proposals[GitHub]. Project proposals submitted to the CNCF (see https://github.com/cncf/toc/blob/master/proposals/kubernetes.adoc[example]) must provide the following information to the best of your ability:
+ . *Project Proposal Requirements*. Projects must be proposed via https://github.com/cncf/toc/tree/master/proposals[GitHub]. Project proposals submitted to the CNCF (see https://github.com/cncf/toc/blob/master/proposals/kubernetes.adoc[example]) can be written in [Markdown](https://www.markdownguide.org/), [AsciiDoc](http://asciidoc.org/), or [reStructuredText](http://docutils.sourceforge.net/rst.html) and must provide the following information to the best of your ability:
 
  .. name of project (must be unique within CNCF)
  .. project description (what it does, why it is valuable, origin and history)

--- a/process/project_proposals.adoc
+++ b/process/project_proposals.adoc
@@ -1,7 +1,7 @@
 == CNCF Project Proposal Process v1.2
 
  . *Introduction*. This governance policy sets forth the proposal process for projects to be accepted into the Cloud Native Computing Foundation (“CNCF”). The process is the same for both existing projects which seek to move into the CNCF, and new projects to be formed within the CNCF.
- . *Project Proposal Requirements*. Projects must be proposed via https://github.com/cncf/toc/tree/master/proposals[GitHub]. Project proposals submitted to the CNCF (see https://github.com/cncf/toc/blob/master/proposals/kubernetes.adoc[example]) can be written in [Markdown](https://www.markdownguide.org/), [AsciiDoc](http://asciidoc.org/), or [reStructuredText](http://docutils.sourceforge.net/rst.html) and must provide the following information to the best of your ability:
+ . *Project Proposal Requirements*. Projects must be proposed via https://github.com/cncf/toc/tree/master/proposals[GitHub]. Project proposals submitted to the CNCF (see https://github.com/cncf/toc/blob/master/proposals/kubernetes.adoc[example]) can be written in https://www.markdownguide.org[Markdown], http://asciidoc.org[AsciiDoc], or http://docutils.sourceforge.net/rst.html[reStructuredText] and must provide the following information to the best of your ability:
 
  .. name of project (must be unique within CNCF)
  .. project description (what it does, why it is valuable, origin and history)


### PR DESCRIPTION
The TOC proposal guidelines don't specify which document types are acceptable for proposals. There seems to be a perception that the proposals need to be in AsciiDoc, which is *not* the case. This PR updates the project proposal document to specify allowable document types. I've listed Markdown, AsciiDoc, and rST here but I'm open to discussion regarding that list.