### PR TITLE
Add link to new SIGs doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ To join: https://lists.cncf.io/mailman/listinfo/cncf-toc
 
 In various situations the CNCF TOC shall hold a vote. These votes can happen on the phone, email, or via a voting service, when appropriate. TOC members can either respond "agree, yes, +1", "disagree, no, -1", or "abstain". A vote passes with two-thirds vote of votes cast based on the charter (see [6(c)(viii)](https://www.cncf.io/about/charter)). An abstain vote equals not voting at all.
 
+## SIGs
+
+The TOC has approved the formation of [SIGs](sigs/cncf-sigs.md).
+
 ## Working Groups
 
 The TOC has created the following working groups to investigate and discuss the following topics:


### PR DESCRIPTION
We'll restructure properly following #214, but we may as well have a link to the new SIGs doc straight away 