### PR TITLE
Add possibility of SIG assessment

### DIFF
--- a/process/project_proposals.adoc
+++ b/process/project_proposals.adoc
@@ -23,6 +23,6 @@
 
 . *Project Acceptance Process*.
  .. Project is proposed via a GitHub issue
- .. TOC may request that a [CNCF SIG](https://github.com/cncf/toc/blob/master/sigs/cncf-sigs.md) assesses the project 
+ .. TOC may request that a https://github.com/cncf/toc/blob/master/sigs/cncf-sigs.md[CNCF SIG] assesses the project 
  .. Projects are required to present their proposal at a TOC meeting
  .. Projects get accepted via a 2/3 supermajority vote of the TOC

--- a/process/project_proposals.adoc
+++ b/process/project_proposals.adoc
@@ -11,7 +11,7 @@
  .. license (charter dictates http://www.apache.org/licenses/LICENSE-2.0[Apache 2] by default)
  .. source control (GitHub by default)
  .. external dependencies (including licenses)
- .. initial committers (how long working on project)
+ .. initial committers (how long working on project, companies they represent)
  .. infrastructure requests (CI / CNCF Cluster)
  .. communication channels (slack, irc, mailing lists)
  .. issue tracker (GitHub by default)
@@ -22,5 +22,7 @@
  .. project logo in svg format (see https://github.com/cncf/artwork#cncf-related-logos-and-artwork for guidelines)
 
 . *Project Acceptance Process*.
+ .. Project is proposed via a GitHub issue
+ .. TOC may request that a [CNCF SIG](https://github.com/cncf/toc/blob/master/sigs/cncf-sigs.md) assesses the project 
  .. Projects are required to present their proposal at a TOC meeting
  .. Projects get accepted via a 2/3 supermajority vote of the TOC


### PR DESCRIPTION
Modified Project Acceptance Process to include the possibility of a SIG assessment step. What this assessment consists of is left open - could be tightened up later. 

Also noted that we generally want to know what companies are represented in the project committers.

* TOC folks, does this agree with your understanding of the process? 
* Is this significant enough to warrant a semver increment in the header? (Do people use / need the semver for processes like this?) 