### PR TITLE
SIG-Security charter, roles, etc.

### DIFF
--- a/sigs/security.md
+++ b/sigs/security.md
@@ -1,0 +1,17 @@
+# CNCF SIG-Security: Special Interest Group on Security
+
+* [Charter](https://github.com/cncf/sig-security/blob/master/governance/charter.md) - reviewed by and contributed to by Jeyappragash JJ, Sarah Allen,
+Dan Shaw, Brandon Lum, with additional contributions by Alexis Richardson,
+Quinton Hoole and members of SIG-Security (formerly known as SAFE WG), with
+final review by Liz Rice, Joe Beda and Zhipeng Huang.
+* [Current CNCF Projects](https://github.com/cncf/sig-security/blob/master/governance/cncf-projects.md)
+
+# Roles
+
+**TOC Liaisons:** Liz Rice, Joe Beda
+
+**Co-Chairs:** Sarah Allen, Dan Shaw, Jeyappragash JJ
+
+**Tech Leads:** TBD (co-chairs to act as tech leads until at least two Technical Leads are identified, see [roles](https://github.com/cncf/sig-security/blob/master/governance/roles.md#role-of-chairs))
+
+For complete details on process and elaboration of rules, see [SIG-Security governance](https://github.com/cncf/sig-security/tree/master/governance)


### PR DESCRIPTION
reference to SIG charter & roles for approval by CNCF TOC