### PR TITLE
create readme for readability/maintainability

### DIFF
--- a/sigs/README.md
+++ b/sigs/README.md
@@ -1,0 +1,20 @@
+# CNCF Special Interest Groups ("SIGs")
+
+The CNCF TOC Special Interest Groups scale contributions by the CNCF
+technical and user community, while retaining integrity and increasing quality
+in support of our [mission](https://github.com/cncf/foundation/blob/master/charter.md#1-mission-of-the-cloud-native-computing-foundation).
+
+TOC and TOC Contributors have fulfilled SIG duties in the past and will continue to do so until a specific SIG takes on that responsibility.
+
+## SIG Formation Process
+
+TOC will identify at least one voting member as TOC Liason for each [proposed SIG](proposed.md).  The SIG TOC Liason will work with TOC contributors identify prospective chairs and draft the initial charter (see [worked example](https://docs.google.com/document/d/18ufx6TjPavfZubwrpyMwz6KkU-YA_aHaHmBBQkplnr0/edit?usp=sharing), then submit
+a pull request with document referencing the roles and charter, updating the list of current SIGs below.
+
+## Current SIGS
+
+* none yet defined
+
+## History
+* November 2018 - January 2019: the SIG process was developed by the CNCF TOC
+and Contributors

--- a/sigs/cncf-sigs.md
+++ b/sigs/cncf-sigs.md
@@ -1,11 +1,9 @@
 
 # CNCF Special Interest Groups ("SIGs")
 
-Proposal by the CNCF TOC and Contributors
-
 Primary Authors: Alexis Richardson, Quinton Hoole
 
-November 2018 - January 2019
+with contributions by TOC Contributors, November 2018 - January 2019
 
 v1.0
 
@@ -154,24 +152,3 @@ As a starting point let’s be inspired by CNCF OSS Projects and by K8S SIGs.  T
     * Must retire the SIG after 6 months
 
 * The TOC may, by means of a 2/3 majority vote, declare "no confidence" in the SIG.  In this event, the TOC may then vote to retire or reconstitute the SIG.
-
-## Initial SIGS
-
-To bootstrap the process, the TOC proposes the following SIGs, and projects assigned to each SIG. Clearly all of these SIG’s will not be fully-formed overnight or begin operating immediately, so the TOC itself will fulfill the duties of not-yet-formed SIG’s until they are.  We can however, fairly immediately, assign one voting member of the TOC as liason for each SIG, and prioritize the order of formation of the SIGs, starting immediately with the most pressing ones. 
-
-
-| Name (to be finalised)  | Area        | Current CNCF Projects 
-| ------------------------|-------------|-----------------------
-| Traffic | networking, service discovery, load balancing, service mesh, RPC, pubsub, etc. | Envoy, Linkerd, NATS, gRPC, CoreDNS, CNI
-| Observability | monitoring, logging, tracing, profiling, etc. | Prometheus, OpenTracing, Fluentd, Jaeger, Cortex, OpenMetrics
-| Governance | security, authentication, authorization, auditing, policy enforcement, compliance, GDPR, cost management, etc. | SPIFFE, SPIRE, Open Policy Agent, Notary, TUF,  Falco
-| App Dev, Ops & Testing | PaaS, Serverless, Operators, CI/CD,  Conformance, Chaos Eng, Scalability and Reliability measurement etc. | Helm, CloudEvents, Telepresence, Buildpacks
-| Core and Applied Architectures | orchestration, scheduling, container runtimes, sandboxing technologies, packaging and distribution, specialized architectures thereof (e.g. Edge, IoT, Big Data, AI/ML, etc). | Kubernetes, containerd, rkt, Harbor, Dragonfly, Virtual Kubelet
-| Storage | Block, File and Object Stores, Databases, Key-Value stores, etc. | TiKV, etcd, Vitess, Rook
-
-
-The TOC and CNCF Staff will draft an initial set of charters for the above, and solicit/elect suitable chairs.
-
-## Appendix A: Worked Example - CNCF Governance SIG
-
-See [separate document](https://docs.google.com/document/d/18ufx6TjPavfZubwrpyMwz6KkU-YA_aHaHmBBQkplnr0/edit?usp=sharing). 

--- a/sigs/proposed.md
+++ b/sigs/proposed.md
@@ -1,0 +1,11 @@
+# Proposed SIGs
+
+| Name (to be finalised)  | Area        | Current CNCF Projects
+| ------------------------|-------------|-----------------------
+| Traffic | networking, service discovery, load balancing, service mesh, RPC, pubsub, etc. | Envoy, Linkerd, NATS, gRPC, CoreDNS, CNI
+| Observability | monitoring, logging, tracing, profiling, etc. | Prometheus, OpenTracing, Fluentd, Jaeger, Cortex, OpenMetrics
+| Governance | security, authentication, authorization, auditing, policy enforcement, compliance, GDPR, cost management, etc. | SPIFFE, SPIRE, Open Policy Agent, Notary, TUF,  Falco
+| App Dev, Ops & Testing | PaaS, Serverless, Operators, CI/CD,  Conformance, Chaos Eng, Scalability and Reliability measurement etc. | Helm, CloudEvents, Telepresence, Buildpacks
+| Core and Applied Architectures | orchestration, scheduling, container runtimes, sandboxing technologies, packaging and distribution, specialized architectures thereof (e.g. Edge, IoT, Big Data, AI/ML, etc). | Kubernetes, containerd, rkt, Harbor, Dragonfly, Virtual Kubelet
+| Storage | Block, File and Object Stores, Databases, Key-Value stores, etc. | TiKV, etcd, Vitess, Rook
+


### PR DESCRIPTION
small refactor to make this more approachable for newcomers
- provide a index to SIGs and high level description
- factor out proposed SIGs into their own doc 
- small change to front matter of process doc since it is no longer a proposal

The idea is that when a new SIG is created, it can be removed from proposed.md and added into the README index, then it is easy to see the list of SIGs to be created and for people to find SIGs that are available to join