### PR TITLE
Correct spelling errors of 'Sandbox Exit Requirements'

### DIFF
--- a/process/sandbox.md
+++ b/process/sandbox.md
@@ -92,9 +92,9 @@ Some key points:
 
 * Existing incubation criteria: [https://github.com/cncf/toc/blob/master/process/graduation_criteria.adoc](https://github.com/cncf/toc/blob/master/process/graduation_criteria.adoc)
 
-    * Require 2/3 votes from the TOC to enter incubation
+    * Require a 2/3 majority vote from the TOC to enter incubation
     * Used successfully in production by at least three independent end users which, in the TOC’s judgement, are of adequate quality and scope.
     * Have a healthy number of committers
     * Full [due diligence](https://github.com/cncf/toc/blob/master/process/due-diligence-guidelines.md) by the TOC
 
-* Archiving criteria: projects may be archived via a 2/3 votes from the TOC
+* Archiving criteria: projects may be archived via a 2/3 majority vote from the TOC

--- a/process/sandbox.md
+++ b/process/sandbox.md
@@ -92,9 +92,9 @@ Some key points:
 
 * Existing incubation criteria: [https://github.com/cncf/toc/blob/master/process/graduation_criteria.adoc](https://github.com/cncf/toc/blob/master/process/graduation_criteria.adoc)
 
-    * Require 2/3 vote from the TOC to enter incubation
+    * Require 2/3 votes from the TOC to enter incubation
     * Used successfully in production by at least three independent end users which, in the TOC’s judgement, are of adequate quality and scope.
     * Have a healthy number of committers
     * Full [due diligence](https://github.com/cncf/toc/blob/master/process/due-diligence-guidelines.md) by the TOC
 
-* Archiving criteria: projects may be archived via a 2/3 vote from the TOC
+* Archiving criteria: projects may be archived via a 2/3 votes from the TOC


### PR DESCRIPTION
The 2/3 of the votes are larger than one, and the 'vote' should be plural.