### PR TITLE
Broken link

### DIFF
--- a/PRINCIPLES.md
+++ b/PRINCIPLES.md
@@ -38,7 +38,7 @@ In the GitHub era, open projects are able to get a lot “done” without outsid
 - But: we do not want to impose bureaucracy on projects because that will slow them down.
 - Minimal viable governance also means that the TOC does not step in at a tactical level to overrule project leads’ decisions.
 - There are some basics like [Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md) - see Draft Statement below. Including dealing with problematic leads & maintainers.
-- There is a formal & regulated system of [Graduation Criteria](https://www.cncf.io/projects/graduation-criteria/) for CNCF Projects
+- There is a formal & regulated system of [Graduation Criteria](https://github.com/cncf/toc/blob/master/process/graduation_criteria.adoc) for CNCF Projects
 - The TOC/CNCF want the ability to intervene if things go really wrong - i.e., project leads are stuck and cannot fix things.
 - Provide a template for new projects, a set of best practices to help jump-start the task of setting up a new project.
 


### PR DESCRIPTION
The link to the Graduation Criteria in the CNCF site is broken. The website references Github itself:
https://github.com/cncf/toc/blob/master/process/graduation_criteria.adoc