### PR TITLE
Explain abbreviation "GB"

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The CNCF TOC is the technical governing body of the CNCF Foundation. It admits and oversees all projects in the CNCF Foundation and has a mandate to facilitate driving neutral consensus for:
 * defining and maintaining the technical vision for the Cloud Native Computing Foundation,
-* approving new projects within the scope for CNCF set by the Governing Board, and create a conceptual architecture for the projects,aligning projects, removing or archiving projects,
+* approving new projects within the scope for CNCF set by the Governing Board (GB), and create a conceptual architecture for the projects,aligning projects, removing or archiving projects,
 * accepting feedback from end user committee and map to projects,
 * aligning interfaces to components under management (code reference implementations before standardizing), and defining common practices to be implemented across CNCF projects, if any.
 


### PR DESCRIPTION
The abbreviation "GB" is used later but never explained. This PR is super simple and all it does is it adds the abbreviation to the full explanation.