### PR TITLE
Add proposal to archive rkt project

### DIFF
--- a/reviews/archive-rkt.md
+++ b/reviews/archive-rkt.md
@@ -1,0 +1,6 @@
+# Rkt Archiving Review
+
+The rkt project has decreased in activity over time, with the number of [contributors decreasing](
+https://all.devstats.cncf.io/d/54/project-health-table?orgId=1&var-repogroup_name=rkt) steadidly over the last year with no issues being closed in the last three months. There have been [no new maintainers](https://github.com/rkt/rkt/commits/master/MAINTAINERS) added to the project in the last couple of years. The rkt project also has [unpatched](https://github.com/rkt/rkt/issues/3999) [CVEs](https://www.twistlock.com/labs-blog/breaking-out-of-coresos-rkt-3-new-cves).
+
+The TOC is recommending the archival of the rkt project as a CNCF project, which means it will no longer be actively promoted or supported as a CNCF project.


### PR DESCRIPTION
The TOC is recommending the archival of the rkt project as a CNCF project, which means it will no longer be actively promoted or supported as a CNCF project.

Signed-off-by: Chris Aniszczyk <caniszczyk@gmail.com>