### PR TITLE
Fix SIG charter issue and amended chairs names

### DIFF
--- a/sigs/app-delivery.md
+++ b/sigs/app-delivery.md
@@ -7,39 +7,22 @@ Approved September 3rd, 2019
 Reviewed and contributed to by:
 
 * Quinton Hoole
-
 * Gareth Rushgrove
-
 * Alois Reitbauer
-
 * Doug Davis
-
 * Lei Zhang
-
 * Roger Klorese
-
 * Taylor Dolezal
-
 * Jianbo Sun
-
 * Nicolas Trangez
-
 * Carolyn Van Slyck
-
 * Jeremy Rickard
-
 * Marc Campbell
-
 * Shantanu Deshpande
-
 * Xander Grzywinski
-
 * Kunal Parmar
-
 * Ricardo Aravena
-
 * Dave Forgac
-
 * Max Körbächer
 
 ## **Introduction**
@@ -51,9 +34,7 @@ The charter describes the operations of the CNCF SIG Application Delivery. The A
 Consistent with the [CNCF SIG definition](https://github.com/cncf/toc/blob/master/sigs/cncf-sigs.md), the mission of CNCF SIG App Delivery is:
 
 * To collaborate on areas related to developing, distributing, deploying, managing and operating secure cloud-native applications with the target of delivering application in manner of cloud native.
-
 * To develop informational resources including guides, tutorials and white papers to give the community an understanding of best practices, trade-offs, and value-adds regarding to application delivery.
-
 * To identify suitable projects and gaps in the landscape, periodically updating the TOC with suggested actions in a structured manner. This includes helping the TOC with assessments and due diligence of prospective new projects.
 
 ## **Areas considered in Scope**
@@ -61,17 +42,11 @@ Consistent with the [CNCF SIG definition](https://github.com/cncf/toc/blob/maste
 SIG Application Delivery focuses on the following topics of the lifecycle of cloud-native applications:
 
 * Application definition, including description, parameter and configuration
-
 * Guidance and practice for application design and development
-
 * Application bundling and deployment
-
 * Package management
-
 * Application delivery workflow and strategy
-
 * Configuration source driven workflow
-
 * Release management
 
 The SIG will work on developing best practices, fostering collaboration between related projects, working on improving tool interoperability as well as proposing new initiatives and projects when blank spots in the current landscape are identified. 
@@ -79,65 +54,37 @@ The SIG will work on developing best practices, fostering collaboration between 
 For CNCF projects, the scope of application delivery SIG engages, amongst others, with the application management focused ones, for example:
 
 * Brigade
-
 * Buildpacks
-
 * CloudEvents
-
 * Flux
-
 * Helm
-
 * Kubernetes
 
 The following, non exhaustive, sample list of activities and deliverables are in-scope for the SIG:
 
 * Education material to help provide guidance for the community
-
     * Summary and overview of projects available in the community
-
     * Definitions of implementations and patterns for best practices for delivering cloud native applications at enterprise scale
-
     * Tooling composition and tool chain creation based on existing projects. 
-
     * Best practices for development, operations and monitoring workflows
-
 * Application definition, development and distribution
-
     * Application descriptor
-
     * Artifacts (e.g. bundles, packaging, images), package management and repositories
-
     * Configuration customization (e.g. templating and parameter)
-
 * Guidance for application development and architecture
-
     * Reference design of microservices, decomposing monoliths
-
     * Reference design of event-based architectures
-
 * Standard and generic application delivery pattern
-
     * Typical rollout strategy implementations with reference architectures
-
     * Best practices of configuration source driven workflow for application delivery
-
     * Best practices of standard application delivery pipeline
-
 * Other tools or practices which may be involved in the workflow of application delivery, including but not limited to:
-
     * Building and configuration
-
     * Deploying, Orchestration and Patching
-
     * Policy and security
-
     * Debugging and monitoring
-
     * Hosting environments and interoperability (e.g. PaaS, FaaS, CaaS,...)
-
     * CI/CD
-
 * Serverless - Serverless applications are a core part of cloud-native application development and the Serverless WG will migrate to live under this SIG.
 
 ## **Areas considered out of Scope**
@@ -145,31 +92,20 @@ The following, non exhaustive, sample list of activities and deliverables are in
 Anything not explicitly considered in the scope above. Example include:
 
 * Testing.
-
 * Non cloud-native applications. 
-
 * Developer tools which are not closely related to delivering application to cloud.
-
 * Specific programming model or developing framework.
-
 * Definition of standards for components like container images and other infrastructure-level building blocks of cloud-native applications. 
 
 ## **Roadmap**
 
 * White paper explaining "Cloud Native Applications" and the current state of the art as seen in the community:
-
     * **Clarify the terminology** currently in use in the cloud native application space, and the relationships between the various terms.
-
     * Figure out patterns and practices of application definition, distribution, and delivery in the manner of "cloud native" in current community, it may include areas like application development, but it mainly focuses around how to deliver application to cloud.
-
     * Provide some general examples of **how these patterns and practices are currently being used in production** in public or private or hybrid cloud environments.
-
 * Creating an application delivery landscape based on the outputs from the white paper. The SIG will help to reduce confusion and educate users by identifying finer-grained problems and implementation choices. Eg "project X focuses on application level rollout strategy", “project Y focuses on GitOps”.
-
 * Define and standardize generic rollout models covering typical app delivery patterns with concrete use cases and practices. 
-
     * The models include but are not limited to Blue-Green Deployment, A/B Testing, Canary Deployment and Analysis, Progressive Traffic Shifting and GitOps.
-
     * The models are not expected to be bound to any specific runtime or execution engine. If one has to, it may not be a good candidate for this part.
 
 ## **Governance**
@@ -179,25 +115,16 @@ Anything not explicitly considered in the scope above. Example include:
 Lifecycle management of applications is a broad and mainstream topic of Cloud Native computing; therefore this SIG may collaborate with most of the other CNCF SIGs and projects. However, the following groups might have the largest potential interactions:
 
 * **SIG Security** - The publication of guidance or tutorials by the SIG could see the adoption of insecure practices if security isn’t considered as a prerequisite for publication. Collaborating with SIG Security on reviews should help to ensure guidance doesn’t lead to propagating insecure patterns of usage.
-
 * **Kubernetes SIG Apps** - Many projects currently under Kubernetes SIG Apps may overlap with CNCF SIG App Delivery. The application delivery SIG will focus on end-to-end aspects of these projects, including non-Kubernetes platforms and projects where applicable; while Kubernetes SIG Apps will focus on Kubernetes-specific runtime-level concerns. Close collaboration is expected to happen within these two SIGs around different phases for application delivery.
 
 ## **Operations**
 
 * TOC Liaisons: Alexis Richardson and Michelle Noorali
-
-* 3 SIG chairs will be nominated by the TOC Liaisons and elected by the TOC to run and manage SIG App delivery Link to the application form:
-
-[https://docs.google.com/forms/d/e/1FAIpQLScc7IRHbRMVHrrZosPTDYi1NiafJ1o65rReuFHvFV6B33BYfw/viewform](https://docs.google.com/forms/d/e/1FAIpQLScc7IRHbRMVHrrZosPTDYi1NiafJ1o65rReuFHvFV6B33BYfw/viewform) -- closes on Thursday, August 1st at 11:59pm PT
-
-The term length and election schedule will be set by the TOC. Our hope is that all SIGs have one set of rules for this.
-
+* SIG chairs: Alois Reitbauer, Bryan Liles, Lei Zhang (Harry)
 * See [roles](https://github.com/cncf/sig-security/blob/master/governance/roles.md#role-of-chairs) for more information
-
 * Slack channel: #sig-app-delivery in CNCF workspace - [https://cloud-native.slack.com/messages/CL3SL0CP5](https://cloud-native.slack.com/messages/CL3SL0CP5) 
 
 ## **Contact**
 
 * [Slack Channel (#sig-app-delivery)](https://cloud-native.slack.com/messages/CL3SL0CP5 )
-
 * Join SIG-App-Delivery at [lists.cncf.io](http://lists.cncf.io)


### PR DESCRIPTION
It is reported the current charter has format issue which "looks weird". Seems to be the extra blank lines issue.

Also, amended the chairs names in the charter.