### PR TITLE
process:{dd-review,due-diligence}*: fix typos

### DIFF
--- a/process/dd-review-template.md
+++ b/process/dd-review-template.md
@@ -2,7 +2,7 @@
 This page provides project review guidelines to those leading or contributing to due diligence exercises performed by or on behalf of the Technical Oversight Committee of the CNCF.
 
 ## Introduction
-The decision to graduate or promote a project depend on the TOC sponsors of the project performina dn documenting the evaluation process in deciding upon initial or continued inclusion of projects through a Technical Due Diligence ('Tech DD') exercise. Ultimately the voting members of the TOC will, on the basis of this and other information, vote for or against the inclusion of each project at the relevant time.
+The decision to graduate or promote a project depend on the TOC sponsors of the project performing and documenting the evaluation process in deciding upon initial or continued inclusion of projects through a Technical Due Diligence ('Tech DD') exercise. Ultimately the voting members of the TOC will, on the basis of this and other information, vote for or against the inclusion of each project at the relevant time.
 
 ## Technical Due Diligence
 ### Primary Goals

--- a/process/due-diligence-guidelines.md
+++ b/process/due-diligence-guidelines.md
@@ -79,7 +79,7 @@ the detail where necessary.
   Are they appropriate given the intended usage (e.g. cluster-wide shared services need to fail gracefully etc)?
 * What trade-offs have been made regarding performance, scalability, complexity, reliability, security etc?  Are these trade-offs explicit or implicit?
   Why?  Are they appropriate given the intended usage?  Are they user-tunable? 
-* What are the most important holes? No HA? No flow control? Inadequate integration points?
+* What are the most important holes? No High-Availability? No flow control? Inadequate integration points?
 * Code quality.  Does it look good, bad or mediocre to you (based on a spot review).  How thorough are the code reviews? Substance over form.
   Are there explicit coding guidelines for the project?
 * Dependencies.  What external dependencies exist, do they seem justified?
@@ -91,7 +91,7 @@ the detail where necessary.
 
 #### Project
 
-The key high-level questions that the voting TOC members will be looking to have answered are (from the [graduation criteria](https://www.cncf.io/projects/graduation-criteria/):
+The key high-level questions that the voting TOC members will be looking to have answered are (from the [graduation criteria](https://www.cncf.io/projects/graduation-criteria/)):
 
 * Do we believe this is a growing, thriving project with committed contributors?
 * Is it aligned with CNCF's values and mission?


### PR DESCRIPTION
There were a couple of typos in the due diligence documents. Correct
these.

It's also possible that HA means something else.
