### PR TITLE
Create process for Sandbox annual review

### DIFF
--- a/process/sandbox-annual-review.md
+++ b/process/sandbox-annual-review.md
@@ -1,0 +1,43 @@
+# Sandbox annual review 
+
+Sandbox projects are subject to an annual review by the TOC. This is intended to be a lightweight process to ensure that projects are on track, and getting the support they need.
+
+## How to file your annual review
+
+CNCF staff will notify the project maintainers when the project review is due. 
+
+Project maintainers are responsible for agreeing between them who will complete the annual review. One of the maintainers should create the review in GitHub under [cncf/toc/reviews](https://github.com/cncf/toc/tree/master/reviews). 
+
+* Raise a PR titled *[Project name] Annual Review*
+* The PR should include a file called `annual-<project name>-<year>.md` (for example, `annual-amazingproj-2019.md`) with the contents described below
+* Send an email to the TOC mailing list so that the community knows the PR is there and can comment on it
+
+If your annual review isn’t complete within two months of notification, we will take this as a sign that the project is not under active maintenance and the TOC is likely to decide to archive the project. 
+
+## Review outcomes
+
+The outcome of the annual review is either:
+
+* At least three (two before the TOC grows to 11 members) TOC members agree to continue to sponsor the project in Sandbox, or
+* If enough TOC members don’t agree to continue to sponsor the project, we will discuss archiving or other next steps with you. 
+
+Additionally, the TOC might recommend that you apply for Incubation stage. This requires extra work and due diligence so it’s not a possible outcome directly from this lightweight annual review. 
+
+It is fine for projects to stay in the Sandbox indefinitely while it is still active, but if a project has genuinely stalled we can save everyone’s effort by [archiving](https://github.com/cncf/toc/blob/master/process/archiving.md) it. 
+
+## Annual review contents
+
+Your annual review should answer the following questions: 
+
+* Include a link to your project’s devstats page. We will be looking for signs of consistent or increasing contribution activity. Please feel free to add commentary to add colour to the numbers and graphs we will see on devstats.
+* How many maintainers do you have, and which organisations are they from? (Feel free to link to an existing MAINTAINERS file if appropriate.)
+* What do you know about adoption, and how has this changed since your last review / since you joined Sandbox? If you can list companies that are end users of your project, please do so. (Feel free to link to an existing ADOPTERS file if appropriate.)
+* How has the project performed against its goals since the last review?
+* What are the current goals of the project? For example, are you working on major new features? Or are you concentrating on adoption or documentation? 
+* How can the CNCF help you achieve your upcoming goals? 
+* Do you think that your project meets the [criteria for incubation](https://github.com/cncf/toc/blob/master/process/graduation_criteria.adoc#incubating-stage)? 
+
+
+
+
+

--- a/process/sandbox-annual-review.md
+++ b/process/sandbox-annual-review.md
@@ -2,17 +2,19 @@
 
 Sandbox projects are subject to an annual review by the TOC. This is intended to be a lightweight process to ensure that projects are on track, and getting the support they need.
 
+To keep it lightweight, it is a single phase process - the review doesn't first pass through SIGs and then the TOC. The review document is shared with the community and SIG members can comment on each review, as can any other TOC contributor. The intention is to quickly reach a position where TOC members agree to continue sponsorship. 
+
 ## How to file your annual review
 
 CNCF staff will notify the project maintainers when the project review is due. 
 
 Project maintainers are responsible for agreeing between them who will complete the annual review. One of the maintainers should create the review in GitHub under [cncf/toc/reviews](https://github.com/cncf/toc/tree/master/reviews). 
 
-* Raise a PR titled *[Project name] Annual Review*
-* The PR should include a file called `annual-<project name>-<year>.md` (for example, `annual-amazingproj-2019.md`) with the contents described below
+* Raise a PR titled *[Project name] [year] Annual Review*
+* The PR should include a file called `<year>-<project name>-annual.md` (for example, `2019-amazingproj-annual.md`) with the contents described below
 * Send an email to the TOC mailing list so that the community knows the PR is there and can comment on it
 
-If your annual review isn’t complete within two months of notification, we will take this as a sign that the project is not under active maintenance and the TOC is likely to decide to archive the project. 
+If your annual review isn’t submitted within two months of notification, we will take this as a sign that the project is not under active maintenance and the TOC is likely to decide to archive the project. 
 
 ## Review outcomes
 
@@ -32,7 +34,7 @@ Your annual review should answer the following questions:
 * Include a link to your project’s devstats page. We will be looking for signs of consistent or increasing contribution activity. Please feel free to add commentary to add colour to the numbers and graphs we will see on devstats.
 * How many maintainers do you have, and which organisations are they from? (Feel free to link to an existing MAINTAINERS file if appropriate.)
 * What do you know about adoption, and how has this changed since your last review / since you joined Sandbox? If you can list companies that are end users of your project, please do so. (Feel free to link to an existing ADOPTERS file if appropriate.)
-* How has the project performed against its goals since the last review?
+* How has the project performed against its goals since the last review? (We won't penalize you if your goals changed for good reasons.)
 * What are the current goals of the project? For example, are you working on major new features? Or are you concentrating on adoption or documentation? 
 * How can the CNCF help you achieve your upcoming goals? 
 * Do you think that your project meets the [criteria for incubation](https://github.com/cncf/toc/blob/master/process/graduation_criteria.adoc#incubating-stage)? 

--- a/process/sandbox-annual-review.md
+++ b/process/sandbox-annual-review.md
@@ -12,7 +12,7 @@ Project maintainers are responsible for agreeing between them who will complete 
 
 * Raise a PR titled *[Project name] [year] Annual Review*
 * The PR should include a file called `<year>-<project name>-annual.md` (for example, `2019-amazingproj-annual.md`) with the contents described below
-* Send an email to the TOC mailing list so that the community knows the PR is there and can comment on it
+* Send an email to the [TOC mailing list](mailto:cncf-toc@lists.cncf.io) so that the community knows the PR is there and can comment on it
 
 If your annual review isn’t submitted within two months of notification, we will take this as a sign that the project is not under active maintenance and the TOC is likely to decide to archive the project. 
 


### PR DESCRIPTION
We have existing [documentation](https://github.com/cncf/toc/blob/master/process/sandbox.md) that says that Sandbox projects should have an annual review. This PR creates a process for that annual review. 

(This PR supercedes the [Google doc](https://docs.google.com/document/d/1OwahJ8aQ880_JA6H6uLwsaQZ9sKWipcK_4RQ1SDfnGc) originally circulated for initial comments.)