### PR TITLE
Update list of proposed SIGs

### DIFF
--- a/sigs/proposed.md
+++ b/sigs/proposed.md
@@ -1,11 +1,14 @@
 # Proposed SIGs
 
-| Name (to be finalised)  | Area        | Current CNCF Projects
-| ------------------------|-------------|-----------------------
-| Traffic | networking, service discovery, load balancing, service mesh, RPC, pubsub, etc. | Envoy, Linkerd, NATS, gRPC, CoreDNS, CNI
-| Observability | monitoring, logging, tracing, profiling, etc. | Prometheus, OpenTracing, Fluentd, Jaeger, Cortex, OpenMetrics
-| Governance | security, authentication, authorization, auditing, policy enforcement, compliance, GDPR, cost management, etc. | SPIFFE, SPIRE, Open Policy Agent, Notary, TUF,  Falco
-| App Dev, Ops & Testing | PaaS, Serverless, Operators, CI/CD,  Conformance, Chaos Eng, Scalability and Reliability measurement etc. | Helm, CloudEvents, Telepresence, Buildpacks
-| Core and Applied Architectures | orchestration, scheduling, container runtimes, sandboxing technologies, packaging and distribution, specialized architectures thereof (e.g. Edge, IoT, Big Data, AI/ML, etc). | Kubernetes, containerd, rkt, Harbor, Dragonfly, Virtual Kubelet
+The original proposal for SIG areas of responsibility. When all the SIGs have been formed, this page can be retired. Once formed, the information in a SIG's charter takes precedence over the details in this list. 
+
+| Name (to be finalised)  | Area        | Current CNCF Projects | Proposed TOC liaisons | 
+| ------------------------|-------------|-----------------------|-----------------------|
+| Traffic | networking, service discovery, load balancing, service mesh, RPC, pubsub, etc. | Envoy, Linkerd, NATS, gRPC, CoreDNS, CNI | Matt Klein |
+| Observability | monitoring, logging, tracing, profiling, etc. | Prometheus, OpenTracing, Fluentd, Jaeger, Cortex, OpenMetrics | Jeff Brewer |
+| Governance (now [SIG Security](https://github.com/cncf/sig-security)) | security, authentication, authorization, auditing, policy enforcement, compliance, GDPR, cost management, etc. | SPIFFE, SPIRE, Open Policy Agent, Notary, TUF,  Falco | Liz Rice, Joe Beda |
+| App Dev, Ops & Testing (now [SIG App Delivery](https://github.com/cncf/sig-app-delivery)) | PaaS, Serverless, Operators, CI/CD,  Conformance, Chaos Eng, Scalability and Reliability measurement etc. | Helm, CloudEvents, Telepresence, Buildpacks | Michelle Noorali, Alexis Richardson | 
+| Core and Applied Architectures | orchestration, scheduling, container runtimes, sandboxing technologies, packaging and distribution, specialized architectures thereof (e.g. Edge, IoT, Big Data, AI/ML, etc). | Kubernetes, containerd, rkt, Harbor, Dragonfly, Virtual Kubelet | Brendan Burns, Brian Grant |
+| Storage (now [SIG Storage](https://github.com/cncf/sig-storage)) | Block, File and Object Stores, Databases, Key-Value stores | TiKV, etcd, Vitess, Rook, OpenEBS, Longhorn | Xiang Li |
 
 


### PR DESCRIPTION
I see this as a temporary page while SIGs get formed, but it’s useful to have in place for the time being. Also documenting @quinton-hoole’s mail from back in March listing the proposed TOC liaisons.