### PR TITLE
Add TOC liaisons to list of current SIGs

### DIFF
--- a/sigs/README.md
+++ b/sigs/README.md
@@ -13,6 +13,9 @@ a pull request with document referencing the roles and charter, updating the lis
 
 ## Current SIGS
 
-* https://github.com/cncf/sig-security
-* https://github.com/cncf/sig-storage
-* https://github.com/cncf/sig-app-delivery
+| Name | TOC Liaisons |
+|------|--------------| 
+| [SIG Security](https://github.com/cncf/sig-security) | Liz Rice, Joe Beda |
+| [SIG Storage](https://github.com/cncf/sig-storage) | Xiang Li | 
+| [SIG App Delivery](https://github.com/cncf/sig-app-delivery) | Michelle Noorali, Alexis Richardson | 
+


### PR DESCRIPTION
Listing liaisons here so folks don’t have to dig through the individual SIG charters to find who to speak with.  See also #328 
