### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,9 +77,9 @@ Currently, the following Special Interest Groups are active:
 * [SIG-Security](https://github.com/cncf/sig-security)
 * [SIG-Storage](https://github.com/cncf/sig-storage) 
 * [SIG-App-Delivery](https://github.com/cncf/sig-app-delivery)
+* [SIG-Network](https://github.com/cncf/sig-network)
 
 Proposed: 
-* [SIG-Network](https://github.com/cncf/sig-network)
 * [SIG-Runtime](https://github.com/cncf/sig-runtime)
 
 
@@ -90,7 +90,6 @@ The TOC has created the following working groups to investigate and discuss the 
 | Working Group | Chair            | Meeting Time                          | Minutes/Recordings |
 |---------------|------------------|---------------------------------------|--------------------|
 | [CI](https://github.com/cncf/wg-ci)         | Camille Fournier | [4th Tue of every month at 12PM PT](https://zoom.us/my/cncfciwg) | [Youtube](https://www.youtube.com/playlist?list=PLj6h78yzYM2P3_A3ujWHSxOu1IO_bd7Zi)
-| [Networking](https://github.com/cncf/wg-networking) | Ken Owens        |  [1st and 3rd Tue every month at 9AM PT](https://zoom.us/my/cncfnetworkingwg)                                      | [Youtube](https://www.youtube.com/playlist?list=PLj6h78yzYM2M_-K5n67_zTdrPh_PtTKFC)
 | [Serverless](https://github.com/cncf/wg-serverless) | Ken Owens        |  [Thu of every week at 9AM PT](https://zoom.us/my/cncfserverlesswg)                                     | [Youtube](https://www.youtube.com/playlist?list=PLj6h78yzYM2Ph7YoBIgsZNW_RGJvNlFOt)
 
 All meetings are on the public CNCF calendar: https://goo.gl/eyutah


### PR DESCRIPTION
Adding SIG Network to the active SIGs, removing Networking WG as SIG replaces.