### PR TITLE
SIG tech leads - clarifications

### DIFF
--- a/sigs/cncf-sigs.md
+++ b/sigs/cncf-sigs.md
@@ -96,7 +96,7 @@ As a starting point let’s be inspired by CNCF OSS Projects and by K8s SIGs.  T
 1. SIGs are formed by the TOC.  Initial SIGs are listed below, and will be adapted over time as required.  If members of the community believe that additional SIGs are desired, they should propose these to the TOC, with clear justification, and ideally volunteers to lead the SIG. The TOC wishes to have the smallest viable number of SIGs, and for all of them to be highly effective (as opposed to a "SIG sprawl" with large numbers of relatively ineffective SIGS).
 2. SIG has three co-chairs, who are TOC Contributors, recognized as experts in that area, and for their ability to co-lead the SIG to produce the required unbiased outputs.
 3. SIG has one TOC liaison who is a voting member of the TOC acting as an additional non-executive chair on occasions when TOC input is deemed necessary by the TOC or the SIG chairs.
-4. SIG has multiple tech leads who are recognized as (1) experts in the SIG area, (2) leaders of projects in the SIG’s area (3) demonstrating the ability to provide the balanced technical leadership required to produce the required unbiased outputs of the SIG. The reason for having separate chair and tech lead roles is to allow responsibility for primarily administrative functions to be separated from deep technical functions and associated time commitments and skill sets.  Where appropriate, an individual may perform both roles (see below).
+4. SIG has multiple [tech leads](#tech-lead). The reason for having separate chair and tech lead roles is to allow responsibility for primarily administrative functions to be separated from deep technical functions and associated time commitments and skill sets.  Where appropriate, an individual may perform both roles (see below).
 5. Participant diversity is strongly encouraged within SIGs, and SIG chairs are expected to actively encourage a diverse range of community members to take up named roles (see point 7). 
 6. A variety of perspectives is strongly encouraged within SIGs.  To this end, a supermajority (⅔ or more) of chairs or a supermajority of tech leads from a single group of related companies, market segment, etc will be actively discouraged by the TOC.
 7. SIG members are self-declared, so that some SIG work is done by volunteers from the TOC Contributors and community.  To recognise members who make sustained  and valuable contributions to a SIG over time, SIG-defined and assigned roles may be created (e.g. scribe, training or documentation coordinator etc).  SIG’s should document what these roles and responsibilities are, and who performs them, and have them approved by SIG leads. SIGs roles should have active mentoring and shadowing programs to encourage sustainability of the SIG.
@@ -111,8 +111,23 @@ As a starting point let’s be inspired by CNCF OSS Projects and by K8s SIGs.  T
 
 #### Tech Lead
 
-* Leads projects in the SIG’s area.
-* Has the time and ability to perform deep technical dives on projects.   Projects may include formal CNCF projects or other projects in the area covered by the SIG.
+A Tech Lead will typically have a track record of participation in SIG
+activities and/or as TOC Contributors; however, this is not a requirement,
+particularly for new SIGs and to fill vacancies.
+
+Qualifications:
+* Expert in the SIG area
+* Demonstrated ability to provide balanced and inclusive technical leadership,
+  which is needed to produce the required unbiased outputs of the SIG
+* Has the time and ability to perform deep technical dives on cloud native,
+  open source projects. (Projects may include accepted or proposed CNCF projects
+  or other projects in the area covered by the SIG.)
+
+Responsibilities:
+* Leadership or oversight of SIG projects, especially those that result in
+  SIG outputs.
+* Foster an inclusive and welcoming environment.
+* Contribute to regular TOC updates in collaboration with chairs.
 
 #### Other named roles
 

--- a/sigs/cncf-sigs.md
+++ b/sigs/cncf-sigs.md
@@ -142,11 +142,13 @@ Responsibilities:
 
 ### Elections
 
-* The TOC nominates Chairs
-* Chairs are assigned following a 2/3 majority vote of the TOC
-* Terms last for 2 years but staggered such that at least 1 of the chairs is able to maintain continuity
-* The TOC and Chairs nominate Tech leads
-* Tech leads are assigned following a 2/3 majority vote of the TOC and a 2/3 majority vote of SIG Chairs
+* Chairs
+  * Nomination: TOC
+  * Vote: 2/3 majority of the TOC
+  * Terms last for 2 years but staggered such that at least 1 of the chairs is able to maintain continuity
+* Tech leads
+  * Nomination: TOC liaison or Chair
+  * Vote: 2/3 majority of the TOC and 2/3 majority vote of SIG Chairs
 * SIG Chairs and Tech Leads may be unassigned from the SIG at any time following a 2/3 majority vote of the TOC
 
 ### Governance


### PR DESCRIPTION
Some clarifications based on talking about this process with @lizrice @jbeda

* refactor description so all the info about tech leads is under one heading, since i wanted to be able to link to it
* clarify small detail of nomination process (logistical that any TOC liaison *or* Chair may nominate Tech Lead) -- typically will be aligned in advance since approval requires 2/3 vote of each group, but the actual nomination could be done by any of them.  (We figured this would be via email to CNCF TOC email list with async vote, but thought that was overly specific for the official rules)
