### PR TITLE
Interested in contributing to CNCF

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -66,6 +66,7 @@ List below is the official list of TOC contributors, in alphabetical order:
 * Sarah Allen, Independent (sarah@ultrasaurus.com)
 * Siddharth Bhadri, Infoblox (sbhadri@infoblox.com)
 * Steve Dake, IBM (sdake@ibm.com)
+* Swamy D K V, Cisco (swamydkv@gmail.com)
 * Tammy Butow, Gremlin (tammy@gremlin.com)
 * Timothy Chen, Hyperpilot (tim@hyperpilot.io)
 * Vasu Chandrasekhara, SAP SE (vasu.chandrasekhara@sap.com)


### PR DESCRIPTION
Interested in contributing to CNCF. Request to approval.
I am working as a Software Engineer in Cisco for 5G products. As telecom products are becoming cloud native, this will be an opportunity to understand and contribute.