### PR TITLE
Adding Initial Charter for Contributor Strategy

### DIFF
--- a/sigs/contributor-strategy.md
+++ b/sigs/contributor-strategy.md
@@ -1,0 +1,179 @@
+# CNCF SIG Contributor Strategy Charter
+
+Primary Authors: Paris Pittman, Josh Berkus  
+
+Reviewed and/or contributed to by:  
+* Matt Klein
+* Matt Farina  
+* Carolyn Van Slyck  
+* April Nassi
+* Matt Jarvis
+* Gerred Dillon
+* Ken Owens
+* Cheryl Hung
+* Amye Scavarda Perrin
+* Ihor Dvoretskyi
+* Liz Rice
+* Sarah Allen
+
+## Introduction
+This charter describes the operations of the CNCF Special Interest Group (SIG)
+Contributor Strategy. This SIG is responsible for contributor experience,
+sustainability, governance, and openness guidance to help CNCF community groups
+and projects with their own contributor strategies for a healthy project.
+
+Our initial three stakeholders:  
+1 - CNCF projects and their contributors/maintainers,  
+2 - End Users in the broader community and member companies,  
+3 - TOC
+
+## Mission
+Consistent with the CNCF SIG definition, the mission of CNCF SIG Contributor
+Strategy is to collaborate on strategies related to building, scaling, and
+retaining contributor communities, including (people) governance, communications,
+operations, and tools. We want to help grow flourishing, sustainable communities
+with smooth journeys throughout their CNCF project lifecycle.  
+To do that we will:
+* **Create intentional space.** Form a "Maintainers Circle" (name may
+  change) comprised of those interested in growing their projects and joining
+  fellow maintainers in related cross project discussions.
+* **Listen and Advise.** Create informational and training resources including
+guides, tutorials and templates of best practices, trade-offs, strategies,
+building and participating in scalable contributor communities.
+* **Evaluate and Foster.** Helping the TOC with assessments and due diligence of
+prospective new projects by developing community graduation criteria check
+points for rolling feedback and guidance.
+* **Educate and Engage.** Providing guidance to end users on how to engage with
+ contributors and vice versa.
+
+#### In scope:
+The following, non exhaustive, bootstrap list of activities and deliverables are
+in-scope for the SIG:
+* Definition of a contributor. This is helpful across projects for metrics and
+establishing guidelines, programs, and workflows.
+* “Contributing health checks”/’community health checks’ (name tbd) for project
+evaluations at graduation time.
+* Webinars, meetings, and other events to engage with the end user community on
+upstream contributing trainings and engagement programs.  
+* Development of guidelines, documents for project governance, recruiting and
+retaining contributor communities, mentorship, and project maturity.
+* Collection of current state of contributor strategies and governance models
+via surveys, GB reps, and Maintainers Circle (Example: what is the project doing
+  now, challenges, gaps)
+
+#### Out of scope
+* The day to day operations of CNCF SIGs, Kubernetes SIGs, or any community group
+of CNCF or its respective projects of any graduation level.
+* The creation and approval of CNCF SIGs or other community groups; we will
+offer advice but the responsibility lies on the TOC for those matters.
+* CNCF operations and marketing initiatives such as: product review/demo
+webinars, kubecon event planning, branding, stickers, swag, etc
+* Licensing and legal matters
+* Testing
+
+
+## Roadmap
+#### 1) SIG Formation
+Role creation
+Stakeholder reps recruited and identified  
+
+#### 2) Discovery
+Who: CNCF SIGs, projects, and end user community  
+What: Collect information that will help us assess gaps/needs, inventory
+contributor best practices and current operations/programs to identify possible
+templates, standards, and more to help projects scale and sustain  
+How: Surveys (past data and new), focus groups, crowdsourcing
+questions/discussion topics, contributor mailing lists and slack!    
+
+#### 3) Establish working groups
+Create them from discovery or already known gaps while #2 is ongoing. Examples
+include:  
+1. Maintainers Circle
+2. Contributor growth and outreach: docs, diversity, recruitment, retention
+ * includes modern mentoring, succession planning, and staffing contributor role
+  strategies
+3. "Community/Contributor health check"
+  * evaluation criteria  
+  * check-in/review/consulting process  
+4. Open governance guidelines and governance operations best practices
+  * the why, how, and where, your contributors make decisions  
+  * contributor diversity
+
+*Possible future roadmap projects*  
+If you see something here that interests you, join us and start it:  
+* Training: leadership, code of conduct, code reviewing, etc  
+* Contributor metrics and definitions  
+* Automation and self service for contributors, community GitOps
+
+## Governance
+This SIGs topic requires cross collaboration between end users, CNCF SIGs, and
+CNCF projects of all graduation levels.
+
+This SIG should be populated and governed by reps from CNCF projects that want
+to create and run intentional contributor experience programs, a rep(s) from the
+end user committee, and the TOC liaison(s). While the SIG reps do not need to be
+core maintainers, they do need to have a drive for making things better for
+contributors and end users. We welcome industry experts and academics in
+relevant working groups!
+
+Conduct public monthly meetings as a large group and working groups that form
+will have their own meetings. (see #Meetings and Decisions for more)
+
+Check in with the TOC on a monthly basis for a quick overview and challenges
+during a public TOC meeting.
+
+### Members
+
+Members are active participants in the work of the SIG who are entitled to vote
+in any SIG decisions that require a vote.  Any contributor to the SIG is
+eligible to become a member after participating in the work of the SIG for at
+least three months.
+
+In order to prevent the SIG from becoming unbalanced, it will have the following
+limits on who can be a voting member:
+
+Up to one from each participating Incubating or Sandbox CNCF project
+Up to two from each Graduated CNCF project
+One from each SIG-ContribStrat Working Group, generally the lead for that WG
+No more than ⅓ of members from the same employer
+
+If a contributor would be entitled to be a member, but are restricted because of
+the above limits, they are a non-voting member who may participate in meetings
+but cannot vote.
+
+Members who are no longer participating actively in the SIG (including both WG
+  work and the regular meetings) will step down from membership.
+
+#### Chairs and TOC Liaison
+
+- TOC Liaison: Matt Klein   
+- Chairs:
+- Tech Leads: None at this time but can change with need at a later time with
+charter ratification   
+
+In accordance with the terms and roles laid out in [cncf-sigs.md](https://github.com/cncf/toc/blob/master/sigs/cncf-sigs.md)
+
+The TOC will also appoint 3 [Chairs](https://github.com/cncf/toc/blob/master/sigs/cncf-sigs.md#chair)
+
+### Meetings and Decisions
+
+Most SIG work will be carried out without requiring any kind of regular meeting
+or vote. The SIG will have a regular meeting, initially monthly, at which the
+membership may vote on the following items as the come up:
+
+* Addition of new members or removal of inactive ones
+* Approval of new working groups and retirement of completed/inactive ones
+* Approval of reports to be delivered to the TOC
+* Approval of formal recommendations to a CNCF project or about that project to
+the TOC
+* Approval or deprecation of guidelines and documents
+
+### Bootstrapping
+
+Initially, the TOC shall appoint three members in order to launch the SIG
+
+## Reach out!
+Mailing List: [sig-contributor-strategy](mailto:sig-contributor-strategy@lists.cncf.io)
+mailer at [lists.cncf.io](https://lists.cncf.io)  
+[Meeting Notes](https://docs.google.com/document/d/1Xjw-yAqidQW67zv7OfMRErsfCotc-mfQ_248Te_YL0g/edit#heading=h.252i9x89qe0d)  
+Slack channel: [#sig-contributor-strategy]


### PR DESCRIPTION
update: we are [here](https://github.com/cncf/sig-contributor-strategy/pull/2) now

I'll also ask all of the reviewers and contributors to explicitly +1 as there are changes here not reflected on the word doc from recent meetings. 