### PR TITLE
Update SIG liaisons in sig specific md files

### DIFF
--- a/sigs/app-delivery.md
+++ b/sigs/app-delivery.md
@@ -119,7 +119,7 @@ Lifecycle management of applications is a broad and mainstream topic of Cloud Na
 
 ## **Operations**
 
-* TOC Liaisons: Alexis Richardson and Michelle Noorali
+* TOC Liaisons: Michelle Noorali, Katie Gamanji
 * SIG chairs: Alois Reitbauer, Bryan Liles, Lei Zhang (Harry)
 * See [roles](https://github.com/cncf/sig-security/blob/master/governance/roles.md#role-of-chairs) for more information
 * Slack channel: #sig-app-delivery in CNCF workspace - [https://cloud-native.slack.com/messages/CL3SL0CP5](https://cloud-native.slack.com/messages/CL3SL0CP5) 

--- a/sigs/security.md
+++ b/sigs/security.md
@@ -8,7 +8,7 @@ final review by Liz Rice, Joe Beda and Zhipeng Huang.
 
 # Roles
 
-**TOC Liaisons:** Liz Rice, Joe Beda
+**TOC Liaisons:** Liz Rice, Justin Cormack
 
 **Co-Chairs:** Sarah Allen, Dan Shaw, Jeyappragash JJ
 


### PR DESCRIPTION
@lizrice noticed that sigs have liaisons mentioned in their respective md files; updated these files based on https://github.com/cncf/toc/pull/362