### PR TITLE
SIG-Serverless Proposal

### DIFF
--- a/sigs/sig-serverless.md
+++ b/sigs/sig-serverless.md
@@ -1,0 +1,139 @@
+## CNCF Serverless SIG Charter
+
+## Introduction
+
+This is the charter referred to in “[CNCF
+SIGs](https://github.com/cncf/toc/blob/master/sigs/cncf-sigs.md#sig-charter)”
+by the CNCF TOC, and consistent with the [proposed SIG
+definition](https://github.com/cncf/toc/blob/master/sigs/proposed.md).
+
+Borrowing from the [Serverless
+Whitepaper](https://github.com/cncf/wg-serverless/tree/master/whitepapers/serverless-overview),
+Serverless computing refers to the concept of building and running
+applications that do not require server management. Allowing developers
+to focus on writing their applications’ business logic rather than the
+complexities of the platform hosting/managing their applications. As such,
+this SIG will focus on technologies related to enabling this simplified
+developer experience.
+
+## Areas Considered In Scope
+
+Technologies related to hosting, managing, developing and integrating of
+Serverless applications from an application developer's perspective.
+The following are example areas that are considered in scope:
+
+* container hosting platforms that attempt to abstract their complexities away
+  from the application developer
+* orchestration and management of workloads running on those platforms from the
+  application developer's perspective
+* tooling to aid in the development and deployment of those workloads
+* integration technologies that aim to promote interoperability between the
+  various systems that an application developer may interact with during the
+  management of their applications on those platforms
+* workload interoperability - e.g. portability of functions,
+  interaction with hosting environment/runtime
+* interoperability and connectivity with backend services used by worloads
+
+## Areas Considered Out Of Scope
+
+Anything not considered in scope above is out of scope.  See also “Interfaces
+with Related Groups” below.
+
+An example would include technology related to the inner-workings of a
+particular platform. For example, a new autoscaler for Kubernetes.
+
+## SIG Mission Statement
+
+To enable application developers to more easily create, deploy and manage their
+applications without the need to become experts in the hosting technologies
+being used.
+
+Developers should focus their attention on the development of their
+applications. When they are required to spend a significant portion of their
+time learning and interacting with the hosting platform of those applications
+then that is time that should have been spent working on their business
+objective.
+
+To that end, the SIG will:
+
+1. Provide valuable and unbiased information to the TOC,
+   End Users and Projects of the CNCF regarding areas considered in scope
+   (see above).
+2. Collaborate effectively with other related groups (see below).
+3. Help to maintain the continued health of the CNCF Projects deemed
+   to be within the scope of this SIG (see below)
+4. Identify and fill gaps in the landscape of CNCF Projects within scope
+   either through encouragement of existing projects to join the CNCF
+   or through development of new artifacts (e.g. specs, code, papers).
+5. Maintain any "living" documentation, such as landscape and state of the
+   community documents.
+
+Specific SIG deliverables are as per the above, and the [general SIG
+responsibilities set out by the CNCF
+ TOC](https://github.com/cncf/toc/blob/master/sigs/cncf-sigs.md#responsibilities--empowerment-of-sigs).
+
+## Current CNCF Projects Considered To Be Within The Scope Of This SIG
+
+* CloudEvents
+* Serverless Workflow
+* CloudEvents Discovery API
+* CloudEvents Subscription API
+
+## Interfaces With Other Related Groups
+
+It is not always clear where the line is between
+Serverless and other cloud native hosting technologies, therefore the exact
+choice of a project being within scope of SIG-Serverless versus one of the
+other CNCF SIGs will need to be consider on a case by case basis. Often the
+decision might be based on the project's relationship to existing projects
+within the SIG.
+
+*   **[Several Kubernetes SIGs](https://github.com/kubernetes/community)**
+    cover Kubernetes-specific workload, scheduling, autoscaling, execution
+    and other related abstractions, interfaces, and implementations of
+    these interfaces.  We will maintain communication with these Kubernetes
+    SIGs where needed.  Our aim is to avoid unnecessary duplication of
+    effort by the two groups and maintain clear and consistent messaging
+    to our end user community and projects.
+*   **[CNCF Security SIG](https://github.com/cncf/sig-security)**
+    works on the more general area of cloud-native security including
+    authentication, authorization, encryption, accounting, auditing, and
+    related topics.  We defer as much as possible to this group to deal
+    with general security-related issues and liaise closely with them on
+    how to deal with security areas where these arise.
+*   **[CNCF App Delivery SIG](https://github.com/cncf/sig-app-delivery)**
+    is focussed on the development, deployment, operation and testing of
+    cloud-native applications. We collaborate with this SIG where it
+    pertains to helping to ensure that the required underlying workload
+    execution abstractions and mechanisms are suitably provided to support
+    these application-level delivery needs.
+
+## Operating Model
+
+This SIG follows the
+[standard operating
+ guidelines](https://github.com/cncf/toc/blob/master/sigs/cncf-sigs.md#operating-model)
+provided by the TOC unless otherwise stated here.
+
+**Current TOC Liaison:**  ????
+
+**Co-Chairs:** [Doug Davis](https://github.com/duglin/),
+  [Mark Peek](https://github.com/markpeek/),
+  [Ken Owens](https://github.com/kenowens12)
+
+**Tech Leads:** [Doug Davis](https://github.com/duglin/),
+  [Mark Peek](https://github.com/markpeek/)
+
+**Other named roles:** None at present; will be identified as needed
+
+## Meeting Schedule
+
+The CNCF SIG-Serverless group meets every Thursday at 12pm Eastern.
+
+Zoom:
+[https://zoom.us/my/cncfsigserverless](https://zoom.us/my/cncfsigserverless)
+
+Mailing list: Join SIG-Serverless mailing list at
+[lists.cncf.io](https://lists.cncf.io)
+
+Slack channel: [TBD](TBD)  

--- a/sigs/sig-serverless.md
+++ b/sigs/sig-serverless.md
@@ -16,6 +16,14 @@ complexities of the platform hosting/managing their applications. As such,
 this SIG will focus on technologies related to enabling this simplified
 developer experience.
 
+Note: the definition of 'Serverless' can be rather challenging to define
+when trying to distinguish it from the othe CNCF SIGs, in particular
+SIG Application Delivery. Both SIGs share many similar goals, and as such,
+these two SIGs will share a special relationship in that as new projects are
+brought to the CNCF, these two SIGs will need to work together to determine the
+most appropriate home for the project. Often this decision may depend on the
+new project's relationship to the existing projects within each SIG.
+
 ## Areas Considered In Scope
 
 Technologies related to hosting, managing, developing and integrating of
@@ -23,13 +31,19 @@ Serverless applications from an application developer's perspective.
 The following are example areas that are considered in scope:
 
 * container hosting platforms that attempt to abstract their complexities away
-  from the application developer
+  from the application developer. In many cases this could include hiding
+  of the specific deployment artifacts (e.g. container images) used by the
+  hosting platform
 * orchestration and management of workloads running on those platforms from the
-  application developer's perspective
-* tooling to aid in the development and deployment of those workloads
+  application developer's perspective - e.g. auto-scaling, including
+  scaling down to zero
+* tooling to aid in the development and deployment of those workloads. For
+  example, source-to-image tooling
 * integration technologies that aim to promote interoperability between the
   various systems that an application developer may interact with during the
-  management of their applications on those platforms
+  management of their applications on those platforms - e.g.
+  CloudEvents which provides a standardized way to expose common event
+  metadata
 * workload interoperability - e.g. portability of functions,
   interaction with hosting environment/runtime
 * interoperability and connectivity with backend services used by workloads
@@ -106,7 +120,9 @@ within the SIG.
     cloud-native applications. We collaborate with this SIG where it
     pertains to helping to ensure that the required underlying workload
     execution abstractions and mechanisms are suitably provided to support
-    these application-level delivery needs.
+    these application-level delivery needs. We will work very closely with
+	this SIG to determine the best home for any new project since the potential
+	overlap between the two SIG could make this choice a challenge.
 *   **[CNCF Runtime SIG](https://github.com/cncf/sig-runtime)**
     includes projects that are focused on the runtime used to host
     cloud-native applications. While we expect a lot of collaboration with this

--- a/sigs/sig-serverless.md
+++ b/sigs/sig-serverless.md
@@ -32,7 +32,7 @@ The following are example areas that are considered in scope:
   management of their applications on those platforms
 * workload interoperability - e.g. portability of functions,
   interaction with hosting environment/runtime
-* interoperability and connectivity with backend services used by worloads
+* interoperability and connectivity with backend services used by workloads
 
 ## Areas Considered Out Of Scope
 
@@ -107,6 +107,14 @@ within the SIG.
     pertains to helping to ensure that the required underlying workload
     execution abstractions and mechanisms are suitably provided to support
     these application-level delivery needs.
+*   **[CNCF Runtime SIG](https://github.com/cncf/sig-runtime)**
+    includes projects that are focused on the runtime used to host
+    cloud-native applications. While we expect a lot of collaboration with this
+    SIG, the difference can be thought of as SIG-Runtime will be more
+    concerned with the specifics of how runtimes host the application, while
+    SIG-Serverless will be more about how developers interact with the
+    runtime. And in particular, in a way that attempts to abstract the
+    complexities of that runtime.
 
 ## Operating Model
 
@@ -121,8 +129,13 @@ provided by the TOC unless otherwise stated here.
   [Mark Peek](https://github.com/markpeek/),
   [Ken Owens](https://github.com/kenowens12)
 
-**Tech Leads:** [Doug Davis](https://github.com/duglin/),
-  [Mark Peek](https://github.com/markpeek/)
+**Tech Leads:**
+  - Workflow: See project
+  [owners](https://github.com/cncf/wg-serverless/blob/master/workflow/spec/governance/owners.md)
+  - CloudEvents: See project
+  [governance](https://github.com/cloudevents/spec/blob/master/GOVERNANCE.md)
+  - Discovery & Subscription: See project
+  [governance](https://github.com/cloudevents/spec/blob/master/GOVERNANCE.md)
 
 **Other named roles:** None at present; will be identified as needed
 
@@ -136,4 +149,4 @@ Zoom:
 Mailing list: Join SIG-Serverless mailing list at
 [lists.cncf.io](https://lists.cncf.io)
 
-Slack channel: [TBD](TBD)  
+Slack channel: [TBD](TBD) 


### PR DESCRIPTION
The Serverless WG finally decided to pull the trigger and formally ask to be converted into a SIG. The main driver was that there are some projects that do not appear to be a good fit for one of the existing SIGs - such as CloudEvents and it's new set of specs.

If agreed to, the existing WG would be replaced by this SIG. So for the most part this would not really change much of the group's mission or set of activities, it's just a title change more than anything else.

However, the SIG charter does provide a bit more clarity and focus than what we've stated in the past.  While we will still continue to do the things we mentioned (promote serverless), given the potential overlap with other SIGs/technologies, we focused our mission on the "developer experience" side of things. See the propose charter itself for more details on the exact way that we define "developer experience".

Signed-off-by: Doug Davis <dug@us.ibm.com>