### PR TITLE
Add Shida Qiu as a TOC contributor

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -67,6 +67,7 @@ List below is the official list of TOC contributors, in alphabetical order:
 * Ricardo Aravena, Rakuten (raravena80@gmail.com)
 * Rick Spencer, Bitnami	(rick@bitnamni.com)
 * Sarah Allen, Independent (sarah@ultrasaurus.com)
+* Shida Qiu, BoCloud (shidaqiu2018@gmail.com)
 * Siddharth Bhadri, Infoblox (sbhadri@infoblox.com)
 * Steve Dake, IBM (sdake@ibm.com)
 * Tammy Butow, Gremlin (tammy@gremlin.com)


### PR DESCRIPTION
I represent BoCloud to help evaluate potential projects and contribute to working groups.

I have been contributing to CNCF and related eco-system projects for quite a long time. I am an active contributor to project Kubernetes, Istio and so on. And now, my group at BoCloud is contributing to various CNCF areas including Orchestration, Service Mesh, Network, etc.