### PR TITLE
Emissary-ingress proposal for CNCF Incubation

### DIFF
--- a/proposals/incubation/ambassadorapigateway.adoc
+++ b/proposals/incubation/ambassadorapigateway.adoc
@@ -1,0 +1,62 @@
+== Ambassador API Gateway Proposal
+
+*Name of project:* Ambassador API Gateway
+
+*Description:* The Ambassador API Gateway is an open source Kubernetes ingress controller and API Gateway. Ambassador is built on Envoy Proxy. Ambassador supports a wide range of use cases for ingress, including load balancing, authentication, and observability. 
+
+=== Alignment with CNCF
+
+An API Gateway / ingress controller is the standard architecture for managing the flow of north-south (ingress) traffic to services deployed in Kubernetes. This capability is critical to the CNCF's mission of making cloud native computing ubiquitous; the Ambassador API Gateway ties together Kubernetes and Envoy Proxy to centralize the management of traffic from the Internet to services running inside a Kubernetes cluster.
+
+=== Ambassador API Gateway Overview
+
+==== Features
+
+ * Kubernetes-native: Ambassador relies on Kubernetes for storing its configuration state, scaling and self-healing, while exposing its configuration as Custom Resources, via well-defined Custom Resource Definitions (CRDs), such as Mappings
+ * Envoy Inside: Ambassador is built as a control plane for Envoy, the high performance L7 proxy and load balancer
+ * Broad protocol support: Ambassador supports a broad range of protocols including TCP, gRPC, gRPC-Web, HTTP/1, HTTP/1.1, HTTP/2, and WebSockets
+ * TLS management: Ambassador supports SNI, wildcard certificates, and more
+ * Ecosystem integration: Ambassador has integrations with key cloud-native projects, including the CNCF-hosted Prometheus, Linkerd, and Jaeger; and also other projects such as Istio and and Knative
+ * Full Kubernetes Ingress support, including support for Kubernetes 1.18 Ingress API improvements
+
+To learn more about the history of the Ambassador API Gateway, please see https://blog.getambassador.io/building-ambassador-an-open-source-api-gateway-on-kubernetes-and-envoy-ed01ed520844.
+
+=== Project Timeline
+ * Datawire launched and open sourced the Ambassador API Gateway in March 2017 as an ingress controller for Kubernetes, effectively building a north-south traffic management control plane for the Envoy proxy
+ * Version 1.0 of the Ambassador API Gateway was released in January 2020 after one hundred releases and substantial customer adoption
+
+== Select Production Users
+ * AppDirect (https://www.appdirect.com/blog/evolution-of-the-appdirect-kubernetes-network-infrastructure; KubeCon NA 2018 presentation: https://www.youtube.com/watch?v=bbimN1h0gOU)
+ * Lifion by ADP (https://lifion.com/events/5p4u0csn7ev56zp764eidlkm3a3jg3-wrsd4-fmp9f-mxty7-lrmx4-rh6zm-xfzah-cl9gs-w2lpc-cw7fl)
+ * Ticketmaster (https://blog.getambassador.io/case-study-ticketmaster-international-967b7870d972)
+ * Chick-Fil-A (https://medium.com/@cfatechblog/shaping-chick-fil-a-one-traffic-in-a-multi-region-active-active-architecture-6fb982597d45)
+ * OneFootball (KubeCon EU 2019 presentation: https://www.youtube.com/watch?v=07RvO4AChHE)
+
+== Roadmap
+
+The Ambassador API Gateway community constantly asks for improvements and bug fixes. Some of the key work in progress include:
+
+ * Involved in the [Service APIs](https://github.com/kubernetes-sigs/service-apis) and Ingress v1 work to ensure continued support of the evolving Kubernetes standard
+ * Improving the contributor experience with faster tests and better documentation
+ * Better controls for canary, blue/green releases, and traffic shadowing
+
+== CNCF Donation Details
+ * *Preferred Maturity Level:* Incubation
+ * *Sponsors:* @mattklein123
+ * *License:* Apache 2
+ * *Source control repositories / issue tracker:* https://github.com/datawire/ambassador
+ * *Infrastructure Required:* N/A
+ * *Website:* https://github.com/datawire/ambassador
+ * *Release Methodology and Mechanics:* Documented at https://github.com/datawire/ambassador/blob/master/RELEASING.md
+
+== Contributor Statistics (valid as of April 2020)
+ * 2.7k GitHub Stars
+ * 1591 PRs
+ * 1023 Issues Opened
+ * 130 Contributors
+ * 489 releases
+
+== Asks from CNCF
+ * A vendor-neutral home for the Ambassador API Gateway to grow the community
+ * CI/CD infrastructure
+ * Assistance in improving documentation and HOWTOs


### PR DESCRIPTION
This is a proposal for the Ambassador API Gateway to be included as a CNCF Incubation project.

We've discussed the project with several CNCF TOC members, but have not scheduled it for a TOC meeting yet.

Please let us know if anyone has any feedback or questions.

Best wishes,