### PR TITLE
Add Andres Vega to TOC Contributors

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -6,6 +6,7 @@ List below is the official list of TOC contributors, in alphabetical order:
 
 * Alex Chircop, StorageOS (alex.chircop@storageos.com)
 * Allen Sun, Alibaba (allensun.shl@alibaba-inc.com)
+* Andrés Vega, Hewlett-Packard Enterprise (andres.vega@hpe.com)
 * Andy Santosa, Ebay (asantosa@ebay.com)
 * Ara	Pulido, Bitnami	(ara@bitnami.com)
 * Ayrat Khayretdinov (ayratk@google.com)


### PR DESCRIPTION
I want to express my interest to become a TOC Contributor. Happy to be of use and contribute in any way I can. 

I participate actively in SIG-Security where I have led the security assessment for project Harbor and also involved in the development of the CKS certification.  I'm involved in the SPIFFE/SPIRE community as the person responsible for multiple aspects of product, program and project management. 



