### PR TITLE
sig-contrib-strat: Add Stephen Augustus as Chair, Gerred to Emeritus

### DIFF
--- a/sigs/README.md
+++ b/sigs/README.md
@@ -23,7 +23,7 @@ a pull request with document referencing the roles and charter, updating the lis
 | [SIG Contributor Strategy](https://github.com/cncf/sig-contributor-strategy) | Matt Klein |
 | [SIG Observability](https://github.com/cncf/sig-observability) | Jeff Brewer, Brendan Burns | 
 
-## SIG Chairs as of April 2020
+## SIG Chairs as of July 2020
 
 ### SIG Storage 
 * [Erin Boyd](https://github.com/erinboyd)
@@ -52,8 +52,9 @@ a pull request with document referencing the roles and charter, updating the lis
 ### SIG Contributor Strategy
 * [Paris Pittman](https://github.com/parispittman)
 * [Josh Berkus](https://github.com/jberkus)
-* [Gerred Dillon](https://github.com/gerred)
+* [Stephen Augustus](https://github.com/justaugustus)
 
 ### SIG Observability
 * [Matt Young](https://github.com/halcyondude)
 * [Richard Hartmann](https://github.com/RichiH)
+

--- a/sigs/README.md
+++ b/sigs/README.md
@@ -58,3 +58,8 @@ a pull request with document referencing the roles and charter, updating the lis
 * [Matt Young](https://github.com/halcyondude)
 * [Richard Hartmann](https://github.com/RichiH)
 
+## Emeritus Chairs
+
+| SIG | Emeritus Chair |
+|---|---|
+| SIG Contributor Strategy | [Gerred Dillon](https://github.com/gerred) |


### PR DESCRIPTION
Following @gerred's [step-down notice for SIG Contributor Strategy](https://lists.cncf.io/g/cncf-sig-contributor-strategy/topic/stepping_down_as_sig/75106774), this PR reflects Gerred's recommendation and proposes me as a SIG Contributor Strategy Chair.

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

cc(SIG Contributor Strategy Chairs): @parispittman @jberkus