### PR TITLE
Refer to DD guidelines from template

### DIFF
--- a/process/dd-review-template.md
+++ b/process/dd-review-template.md
@@ -1,5 +1,5 @@
 # Due Diligence Project Review Template
-This page provides project review guidelines to those leading or contributing to due diligence exercises performed by or on behalf of the Technical Oversight Committee of the CNCF.
+This page provides a template to help those leading or contributing to due diligence exercises performed by or on behalf of the Technical Oversight Committee of the CNCF. Please also read the [Due Diligence Guidelines](https://github.com/cncf/toc/blob/master/process/due-diligence-guidelines.md). 
 
 ## Introduction
 The decision to graduate or promote a project depends on the TOC sponsors of the project performing and documenting the evaluation process in deciding upon initial or continued inclusion of projects through a Technical Due Diligence ('Tech DD') exercise. Ultimately the voting members of the TOC will, on the basis of this and other information, vote for or against the inclusion of each project at the relevant time.


### PR DESCRIPTION
I think ideally we'd combine the DD guidelines and the DD template Into one doc, but as a quick fix we should make sure that people using the template are also aware of the more detailed guidelines document