### PR TITLE
Improve readability of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,6 @@ Here is a [Google calendar for all public CNCF events](https://goo.gl/eyutah).
 - [Meeting agenda and presentations](docs/meeting_presentations.md).
 - [Archive of community presentations](docs/scheduled_presentations.md)
 
-If you're interested in presenting at a TOC call about your project, please open a [GitHub issue](https://github.com/cncf/toc/issues) with the request. These requests are tracked in the [TOC project backlog](https://github.com/cncf/toc/projects/4).
-
 
 ## Mailing List
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ The CNCF TOC is the technical governing body of the CNCF Foundation. It admits a
 * accepting feedback from end user committee and map to projects,
 * aligning interfaces to components under management (code reference implementations before standardizing), and defining common practices to be implemented across CNCF projects, if any.
 
+
 ## Members
+
 * **Alena Prokharchyk** (term: 2 years - start date: 3/18/2020 - 3/18/2022) [TOC-appointed]
 * **Brendan Burns** (term: 2 years - start date: 1/29/2019 - 1/29/2021) [GB-appointed]
 * **Jeff Brewer** (term: 2 years - start date: 1/29/2019 - 1/29/2021) [EndUser-appointed]
@@ -21,46 +23,49 @@ The CNCF TOC is the technical governing body of the CNCF Foundation. It admits a
 
 Election [schedule](process/election-schedule.md)
 
+
 ## Projects
-See the current CNCF projects and a description of project maturity levels (Sandbox, Incubating, Graduated) [here](https://www.cncf.io/projects/).
 
-[Here](https://www.cncf.io/services-for-projects/) is a list of services that the CNCF provides for Incubating and Graduated projects hosted in the foundation. CNCF also provides a subset of these services to [Sandbox](https://www.cncf.io/sandbox-projects/) level projects.
+See the [current CNCF projects](https://www.cncf.io/projects/) and a description of project maturity levels (Sandbox, Incubating, Graduated).
 
-See the process for contributing a project [here](https://github.com/cncf/toc/blob/master/process/README.md). If you have any questions or don't know where to start, open an [issue](https://github.com/cncf/toc/issues).
+The CNCF provides [list of services](https://www.cncf.io/services-for-projects/) for incubating and graduated projects hosted in the foundation. A subset of these services is also available for [Sandbox](https://www.cncf.io/sandbox-projects/) level projects.
+
+Do you want to contribute to a project? We have [outlined the process](https://github.com/cncf/toc/blob/master/process/README.md) to get started. If you have any questions or don't know where to start, please open an [issue](https://github.com/cncf/toc/issues).
+
 
 ## Meeting Time
 
-The TOC meets on the 1st Tuesday of every month at 8AM PT (USA Pacific).
+The TOC meets on the 1st Tuesday of every month at 8AM PT (USA Pacific Time; [Convert to local time zone](http://www.thetimezoneconverter.com/?t=8:00AM&tz=San%20Francisco)).  
 Project Presentations are on the 3rd Tuesday of every month.
 
 https://zoom.us/j/967220397
 
 Or Telephone:
 
-Dial: +1 646 558 8656 (US Toll) or +1 408 638 0968 (US Toll)
+> Dial:  
+> +1 646 558 8656 (US Toll) or  
+> +1 408 638 0968 (US Toll)  
+> 
+> +1 855 880 1246 (US Toll Free)  
+> +1 877 369 0926 (US Toll Free)
+> 
+> International numbers available [here](https://zoom.us/zoomconference?m=ddKUsXGa2tGOHvCl4ccI0juqU7TZaCov).
+>
+> Meeting ID: 263 858 603
+>
+> NOTE: _Please use `*6` to mute/un-mute your phone during the call_
 
-+1 855 880 1246 (US Toll Free)
-+1 877 369 0926 (US Toll Free)
+Here is a [Google calendar for all public CNCF events](https://goo.gl/eyutah).
 
-Meeting ID: 263 858 603
-
-International numbers available [here](https://zoom.us/zoomconference?m=ddKUsXGa2tGOHvCl4ccI0juqU7TZaCov)
-
-Here is a public Google calendar you can add the meetings to your calendar: https://goo.gl/eyutah
-
-NOTE: Please use *6 to mute/un-mute your phone during the call
-
-Link to a World Time Zone Converter [here](http://www.thetimezoneconverter.com/?t=8:00%20a.m.%20&tz=San%20Francisco&)
 
 ## Meeting Agenda and Minutes
 
-The meeting Working Doc is [here](https://docs.google.com/document/d/1jpoKT12jf2jTf-2EJSAl4iTdA7Aoj_uiI19qIaECNFc/edit#). This includes minutes from previous meetings.
+- [Meeting Working Doc](https://docs.google.com/document/d/1jpoKT12jf2jTf-2EJSAl4iTdA7Aoj_uiI19qIaECNFc/edit#). This includes minutes from previous meetings.
+- [Meeting agenda and presentations](docs/meeting_presentations.md).
+- [Archive of community presentations](docs/scheduled_presentations.md)
 
-Meeting agenda and presentations are [here](docs/meeting_presentations.md).
+If you're interested in presenting at a TOC call about your project, please open a [GitHub issue](https://github.com/cncf/toc/issues) with the request. These requests are tracked in the [TOC project backlog](https://github.com/cncf/toc/projects/4).
 
-An archive of community presentations is [here](docs/scheduled_presentations.md)
-
-If you're interested in presenting at a TOC call about your project, please open a [github issue](https://github.com/cncf/toc/issues) with the request. These requests are tracked in the [TOC project backlog](https://github.com/cncf/toc/projects/4).
 
 ## Mailing List
 
@@ -68,14 +73,17 @@ cncf-toc@lists.cncf.io: https://lists.cncf.io/g/cncf-toc
 
 To join: https://lists.cncf.io/mailman/listinfo/cncf-toc
 
+
 ## Voting
 
-See the voting policy [here](docs/voting.md).
+This is our [voting policy](docs/voting.md).
+
 
 ## SIGs
 
 The TOC has approved the formation of [SIGs](sigs/cncf-sigs.md).
 Currently, the following Special Interest Groups are active: 
+
 * [SIG-Security](https://github.com/cncf/sig-security)
 * [SIG-Storage](https://github.com/cncf/sig-storage) 
 * [SIG-App-Delivery](https://github.com/cncf/sig-app-delivery)
@@ -83,6 +91,7 @@ Currently, the following Special Interest Groups are active:
 * [SIG-Runtime](https://github.com/cncf/sig-runtime)
 * [SIG Contributor Strategy](https://github.com/cncf/sig-contributor-strategy)
 * [SIG Observability](https://github.com/cncf/sig-observability)
+
 
 ## Working Groups
 


### PR DESCRIPTION
As @lizrice asked on [Twitter](https://twitter.com/lizrice/status/1295747218364862464), this is an attempt to improve the readability of the README file.

I tried especially to get rid of the repeating "… can be found [here]()", which also improves accessibility. Now the description of the target link is the actual link text instead.

Still the introduction paragraph about the CNCF TOC sounds way too stiff/technical and should be rephrased to make the responsibilities of the TOC more clear.