### PR TITLE
Spelling error in the German version.

### DIFF
--- a/DEFINITION.md
+++ b/DEFINITION.md
@@ -72,7 +72,7 @@ La Cloud Native Computing Foundation cherche à favoriser l'adoption de ce parad
 
 ## Deutsch:
 
-Cloud native Technologien ermöglichen es Unternehmen, skalierbare Anwendungen in modernen, dynamischen Umgebungen zu implementieren und zu betreiben. Dies können öffentliche, private und Hybrid-Clouds sein. Best-Practises, wie Container, Service-Meshs, Microservices, immutable Infrastruktur und deklarative APIs, unterstützen diesen Ansatz.
+Cloud native Technologien ermöglichen es Unternehmen, skalierbare Anwendungen in modernen, dynamischen Umgebungen zu implementieren und zu betreiben. Dies können öffentliche, private und Hybrid-Clouds sein. Best Practices, wie Container, Service-Meshs, Microservices, immutable Infrastruktur und deklarative APIs, unterstützen diesen Ansatz.
 
 Die zugrundeliegenden Techniken ermöglichen die Umsetzung von entkoppelten Systemen, die belastbar, handhabbar und beobachtbar sind. Kombiniert mit einer robusten Automatisierung können Softwareentwickler mit geringem Aufwand flexibel und schnell auf Änderungen reagieren.
 


### PR DESCRIPTION
Correction of a spelling error in the German version. "Best-Practises" -> "Best Practice".

See e.g. https://www.duden.de/rechtschreibung/Best_Practice.