### PR TITLE
Add "can" to cloud native definition

### DIFF
--- a/DEFINITION.md
+++ b/DEFINITION.md
@@ -7,7 +7,7 @@
 
 Cloud native technologies empower organizations to build and run scalable applications in modern, dynamic
 environments such as public, private, and hybrid clouds. Containers, service meshes, microservices, immutable
-infrastructure, and declarative APIs exemplify this approach.
+infrastructure, and declarative APIs can exemplify this approach.
 
 These techniques enable loosely coupled systems that are resilient, manageable, and observable. Combined with
 robust automation, they allow engineers to make high-impact changes frequently and predictably with minimal


### PR DESCRIPTION
https://cloud-native.slack.com/archives/C01F1LVAQCC/p1607974863215600
see thread for reference in the telco space. The main premise is that just because something is using containers or microservices does not automatically make it cloud native. This update would help clarify that those techniques can help make things cloud native, but do not automatically do so.