### PR TITLE
Add requirement for documented security processes

### DIFF
--- a/process/graduation_criteria.adoc
+++ b/process/graduation_criteria.adoc
@@ -29,6 +29,7 @@ To be accepted to incubating stage, a project must meet the sandbox stage requir
  * Demonstrate a substantial ongoing flow of commits and merged contributions.
  * Since these metrics can vary significantly depending on the type, scope and size of a project, the TOC has final judgement over the level of activity that is adequate to meet these criteria
  * A clear versioning scheme.
+ * Clearly documented security processes explaining how to report security issues to the project, and describing how the project provides updated releases or patches to resolve security vulnerabilities 
  * Specifications must have at least one public reference implementation.
 
 === Graduation Stage


### PR DESCRIPTION
As discussed in TOC meeting Feb 16. The idea is not to impose any particular security processes, just to clarify that they must be in place. 
I'm proposing that this should be in place at Incubation level, since we expect it to be in production with some users at that stage.

See also 
* https://github.com/cncf/sig-security/issues/538 where SIG Security have offered to assess whether existing incubated / graduated projects have process in place
* https://github.com/cncf/sig-security/issues/183 on providing a template - TOC doesn't want to *impose* a specific process, but guidance for projects would be helpful
