### PR TITLE
Adding TOC Liaisons into SIG Charters

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The CNCF TOC is the technical governing body of the CNCF Foundation. It admits a
 * **Dave Zolotusky** (term: 2 years - start date: 2/1/2021 - 2/1/2023) [EndUser-appointed]
 * **Justin Cormack** (term: 2 years - start date 2/4/2020 - 2/4/2022) [Maintainer-appointed]
 * **Ricardo Rocha** (term: remainder of 2 years - start date 2/1/2021 - 2/4/2022) [EndUser-appointed]
-* **Liz Rice** (term: 2 years - start date: 2/4/2020 - 2/4/2022) [GB-appointed]
+* **Liz Rice** (term: 2 years - start date: 2/4/2020 - 2/4/2022) [GB-appointed] (TOC Chair)
 * **Cornelia Davis** (term: 2 years - start date: 2/1/2021 - 2/1/2023) [GB-appointed]
 * **Davanum Srinivas** (term: 2 years - start date: 3/18/2021 - 3/18/2023) [TOC-appointed]
 * **Saad Ali** (term: 2 years - start date 2/4/2020 - 2/4/2022) [GB-appointed]

--- a/sigs/app-delivery.md
+++ b/sigs/app-delivery.md
@@ -119,7 +119,7 @@ Lifecycle management of applications is a broad and mainstream topic of Cloud Na
 
 ## **Operations**
 
-* TOC Liaisons: [Michelle Noorali](https://github.com/michelleN), Katie Gamanji
+* TOC Liaisons: Davanum Srinivas, Lei Zhang, Cornelia Davis
 * SIG chairs: [Alois Reitbauer](https://github.com/AloisReitbauer), [Bryan Liles]((https://github.com/bryanl)), [Lei Zhang (Harry)](https://github.com/resouer)
 * See [roles](https://github.com/cncf/sig-security/blob/main/governance/roles.md#role-of-chairs) for more information
 * Slack channel: #sig-app-delivery in CNCF workspace - [https://cloud-native.slack.com/messages/CL3SL0CP5](https://cloud-native.slack.com/messages/CL3SL0CP5) 

--- a/sigs/contributor-strategy.md
+++ b/sigs/contributor-strategy.md
@@ -1,0 +1,174 @@
+# CNCF SIG Contributor Strategy Charter
+
+Primary Authors: Paris Pittman, Josh Berkus  
+
+Reviewed and/or contributed to by:  
+* Matt Klein
+* Matt Farina  
+* Carolyn Van Slyck  
+* April Nassi
+* Matt Jarvis
+* Gerred Dillon
+* Ken Owens
+* Cheryl Hung
+* Amye Scavarda Perrin
+* Ihor Dvoretskyi
+* Liz Rice
+* Sarah Allen
+
+## Introduction
+This charter describes the operations of the CNCF Special Interest Group (SIG)
+Contributor Strategy. This SIG is responsible for contributor experience,
+sustainability, governance, and openness guidance to help CNCF community groups
+and projects with their own contributor strategies for a healthy project.
+
+Our initial three stakeholders:  
+1 - CNCF projects and their contributors/maintainers,  
+2 - End Users in the broader community and member companies,  
+3 - TOC
+
+## Mission
+Consistent with the CNCF SIG definition, the mission of CNCF SIG Contributor
+Strategy is to collaborate on strategies related to building, scaling, and
+retaining contributor communities, including (people) governance, 
+communications, operations, and tools. We want to help grow flourishing, 
+sustainable communities with smooth journeys throughout their CNCF project 
+lifecycle.   
+To do that we will:
+* **Create intentional space.** Form a "Maintainers Circle" (name may
+  change) comprised of those interested in growing their projects and joining
+  fellow maintainers in related cross project discussions.
+* **Listen and Advise.** Create informational and training resources including
+guides, tutorials and templates of best practices, trade-offs, strategies,
+building and participating in scalable contributor communities.
+* **Evaluate and Foster.** Helping the TOC with assessments and due diligence of
+prospective new projects by developing community graduation criteria check
+points for rolling feedback and guidance.
+* **Educate and Engage.** Providing guidance to end users on how to engage with
+ contributors and vice versa.
+
+#### In scope:
+The following, non exhaustive list of activities and deliverables are
+in-scope for the SIG:
+* Definition of a contributor. This is helpful across projects for metrics and
+establishing guidelines, programs, and workflows.
+* Contributor and goverance related proposed/suggested/modified project 
+lifecycle requirements for graduation or incubation
+* “Contributing health checks”/’community health checks’ (name tbd) for project
+evaluations at graduation time  
+* Webinars, meetings, and other events to engage with the end user and CNCF 
+project community on upstream contributing trainings and engagement programs.  
+* Development of guidelines, documents for project governance, recruiting and
+retaining contributor communities, mentorship, and project maturity.
+* Collection of current state of contributor strategies and governance models
+via surveys, GB reps, and Maintainers Circle (Example: what is the project doing
+  now, challenges, gaps)
+
+#### Out of scope
+* The day to day operations of CNCF SIGs, Kubernetes SIGs, or any community 
+group of CNCF or its respective projects of any graduation level.
+* The creation and approval of CNCF SIGs or other community groups; we will
+offer advice but the responsibility lies on the TOC for those matters.
+* CNCF operations and marketing initiatives such as: product review/demo
+webinars, kubecon event planning, branding, stickers, swag, etc
+* Licensing and legal matters
+* Testing
+
+
+## Current Roadmap
+In no particular order,
+* Launch the maintainers circle and build community 
+  * Training and discussion: inclusive language, code of conduct, code 
+  reviewing, leadership, and more
+* Continue making recommendations to TOC for project lifecycle milestones as it 
+relates to contributor strategy and governance topics (example: multi-org 
+contributing requirement, community management, etc)
+* Create a project template repo for projects to use as they see fit in a fork 
+all or some approach (example: CONTRIBUTING.md, CONTRIBUTOR-LADDER.md templates)
+
+
+*Possible future roadmap projects*  
+If you see something here that interests you, join us and start it:  
+* Contributor metrics and definitions  
+* Automation and self service for contributors, community GitOps
+
+## Governance
+This SIGs topic requires cross collaboration between end users, CNCF SIGs, and
+CNCF projects of all graduation levels.
+
+This SIG should be populated and governed by reps from CNCF projects that want
+to create and run intentional contributor experience programs, a rep(s) from the
+end user committee, and the TOC liaison(s). While the SIG reps do not need to be
+core maintainers, they do need to have a drive for making things better for
+contributors and end users. We welcome industry experts and academics in
+relevant working groups!
+
+Conduct public monthly meetings as a large group and working groups that form
+will have their own meetings. (see #Meetings and Decisions for more)
+
+Check in with the TOC on a monthly basis for a quick overview and challenges
+during a public TOC meeting.
+
+### Members
+
+Members are active participants in the work of the SIG who are entitled to vote
+in any SIG decisions that require a vote.  Any contributor to the SIG is
+eligible to become a member after participating in the work of the SIG for at
+least three months.
+
+In order to prevent the SIG from becoming unbalanced, it will have the following
+limits on who can be a voting member:
+
+Up to one from each participating Incubating or Sandbox CNCF project
+Up to two from each Graduated CNCF project
+One from each SIG-ContribStrat Working Group, generally the lead for that WG
+No more than ⅓ of members from the same employer
+
+If a contributor would be entitled to be a member, but are restricted because of
+the above limits, they are a non-voting member who may participate in meetings
+but cannot vote.
+
+Members who are no longer participating actively in the SIG (including both WG
+  work and the regular meetings) will step down from membership.
+
+#### Chairs and TOC Liaison
+
+- TOC Liaison: Saad Ali, Alena Prokharchyk  
+- Chairs: Josh Berkus, Stephen Augustus, Paris Pittman  (Emeritus: Gerred 
+Dillon)
+- Tech Leads: None at this time but can change with need at a later time with
+charter ratification   
+
+In accordance with the terms and roles laid out in [cncf-sigs.md](https://github.com/cncf/toc/blob/master/sigs/cncf-sigs.md)
+
+The TOC will also appoint 3 [Chairs](https://github.com/cncf/toc/blob/master/sigs/cncf-sigs.md#chair)
+
+### Meetings and Decisions
+
+Most SIG work will be carried out without requiring any kind of regular meeting
+or vote. The SIG will have a regular meeting, bi-weekly, at which the
+membership may vote on the following items as the come up:
+
+* Addition of new members or removal of inactive ones
+* Approval of new working groups and retirement of completed/inactive ones
+* Approval of reports to be delivered to the TOC
+* Approval of formal recommendations to a CNCF project or about that project to
+the TOC
+* Approval or deprecation of guidelines and documents
+
+### Bootstrapping
+
+Initially, the TOC shall appoint three members in order to launch the SIG
+
+## Reach out!
+Mailing List: [sig-contributor-strategy](mailto:sig-contributor-strategy@lists.cncf.io)
+mailer at [lists.cncf.io](https://lists.cncf.io)  
+[Meeting Notes](https://docs.google.com/document/d/1Xjw-yAqidQW67zv7OfMRErsfCotc-mfQ_248Te_YL0g/edit#heading=h.252i9x89qe0d)  
+Slack channel: [#sig-contributor-strategy]  
+Public Meetings: Bi-weekly on Thursday at 5:30pm UTC. Join our mailing list for
+
+
+[cncf-sigs.md]: https://github.com/cncf/toc/blob/master/sigs/cncf-sigs.md
+[sig-contributor-strategy]: mailto:sig-contributor-strategy@lists.cncf.io
+[lists.cncf.io]: https://lists.cncf.io
+[Meeting Notes]: https://docs.google.com/document/d/1Xjw-yAqidQW67zv7OfMRErsfCotc-mfQ_248Te_YL0g/edit#heading=h.252i9x89qe0d

--- a/sigs/network.md
+++ b/sigs/network.md
@@ -94,7 +94,7 @@ This SIG follows the [standard operating model](https://github.com/cncf/toc/blob
 
 ## Chairs:
 
-- TOC Liaison: [Matt Klein](https://twitter.com/mattklein123)
+- TOC Liaison: [Dave Zolotusky](https://twitter.com/dzolotusky), [Liz Rice](https://twitter.com/lizrice)
 - SIG Chairs: [Lee Calcote](https://twitter.com/lcalcote), [Ken Owens](https://twitter.com/kenowens12)
 
 In accordance with the [elections and terms](https://github.com/cncf/toc/blob/main/sigs/cncf-sigs.md#elections) follow the [CNCF SIG definition](https://github.com/cncf/toc/blob/main/sigs/cncf-sigs.md#elections).

--- a/sigs/observability.md
+++ b/sigs/observability.md
@@ -185,9 +185,9 @@ Examples include:
 
 - Formation of the SIG follows the [documented process][sigform].
 - [Roles][sigroles] for SIG Observability
-  - TOC Liaison: *Jeff Brewer*\*
+  - TOC Liaison: 	Lei Zhang, Cornelia Davis
   - SIG Chairs: [Matt Young](https://github.com/halcyondude), [Richard Hartmann](https://github.com/RichiH)
-  - Tech Leads: [Michael Hausenblas](https://github.com/mhausenblas), [Bartłomiej Płotka](https://github.com/bwplotka), *Richard Hartmann*\*
+  - Tech Leads: [Michael Hausenblas](https://github.com/mhausenblas), [Bartłomiej Płotka](https://github.com/bwplotka), 
 
 \*_**(TODO: need confirmation)**_
 

--- a/sigs/proposed.md
+++ b/sigs/proposed.md
@@ -1,10 +1,3 @@
 # Proposed SIGs
 
-| Name (to be finalised)  | Area        | Current CNCF Projects | Proposed TOC liaisons | 
-| ------------------------|-------------|-----------------------|-----------------------|
-| Traffic (now [SIG Network](https://github.com/cncf/sig-network)) | networking, service discovery, load balancing, service mesh, RPC, pubsub, etc. | Envoy, Linkerd, NATS, gRPC, CoreDNS, CNI | Matt Klein |
-| Observability (now [SIG Observability](https://github.com/cncf/sig-observability)) | monitoring, logging, tracing, profiling, etc. | Prometheus, OpenTracing, Fluentd, Jaeger, Cortex, OpenMetrics | Jeff Brewer |
-| Governance (now [SIG Security](https://github.com/cncf/sig-security)) | security, authentication, authorization, auditing, policy enforcement, compliance, GDPR, cost management, etc. | SPIFFE, SPIRE, Open Policy Agent, Notary, TUF,  Falco | Liz Rice, Joe Beda |
-| App Dev, Ops & Testing (now [SIG App Delivery](https://github.com/cncf/sig-app-delivery)) | PaaS, Serverless, Operators, CI/CD,  Conformance, Chaos Eng, Scalability and Reliability measurement etc. | Helm, CloudEvents, Telepresence, Buildpacks | Michelle Noorali, Alexis Richardson | 
-| Core and Applied Architectures (now [SIG Runtime](https://github.com/cncf/toc/tree/main/sigs#sig-runtime) | orchestration, scheduling, container runtimes, sandboxing technologies, packaging and distribution, specialized architectures thereof (e.g. Edge, IoT, Big Data, AI/ML, etc). | Kubernetes, containerd, rkt, Harbor, Dragonfly, Virtual Kubelet | Brendan Burns, Brian Grant |
-| Storage (now [SIG Storage](https://github.com/cncf/sig-storage)) | Block, File and Object Stores, Databases, Key-Value stores | TiKV, etcd, Vitess, Rook, OpenEBS, Longhorn | Xiang Li |
+None at this time

--- a/sigs/runtime-charter.md
+++ b/sigs/runtime-charter.md
@@ -132,9 +132,10 @@ This SIG follows the [standard operating guidelines](https://github.com/cncf/toc
 provided by the TOC unless otherwise stated here.
 
 
-**TOC Liaisons:**  [Brendan Burns](https://github.com/brendandburns), [Alena Prokharchyk](https://github.com/alena1108)
+**TOC Liaisons:**  [Richardo Rocha](https://twitter.com/ahcorporto), [Alena Prokharchyk](https://github.com/alena1108), [Davanum Srinivas](https://twitter.com/dims)
 
-**SIG Chairs:** [Quinton Hoole](https://github.com/quinton-hoole),
+**SIG Chairs:** 
+  [Quinton Hoole](https://github.com/quinton-hoole),
   [Ricardo Aravena](https://github.com/raravena80),
   [Diane Feddema](https://github.com/dfeddema)
 

--- a/sigs/security-charter.md
+++ b/sigs/security-charter.md
@@ -1,0 +1,130 @@
+# SIG-Security Charter
+
+This charter describes operations as a [CNCF SIG](https://github.com/cncf/toc/blob/master/sigs/). The [Focus](#focus) section below describes what is in and out of scope,
+and [Governance](#governance) section describes how our operations are consistent with CNCF policies with links to more detailed documents.
+
+**Mission:** to reduce risk that cloud native
+applications expose end user data or allow other unauthorized access.
+
+## Motivation
+Security has been an area in which open source can flourish and sometimes
+has done so; however, with cloud native platforms and applications, security
+has received less attention than other areas of the cloud native landscape.
+
+This means that there is less visibility about the internals of security
+projects, and fewer projects being deeply integrated into cloud native tooling.
+While there are many open source security projects, there are fewer security
+experts focused on the cloud native ecosystem. This has contributed to a culture
+where people feel they cannot understand how to securely set up and operate
+cloud native systems, due to obscurity and uncertainty. Cloud native principles
+have encouraged the development of tools that help manage fast changing
+environments, and which have the promise of both simplifying and improving
+security.
+
+Making security more open and understandable is an essential part of this
+change. Talking to customers, security is the most important and least
+understood part of the cloud native transition. Security is not an easy field,
+and it is difficult to measure and value the inputs precisely, which can also
+cause issues with evaluation of security software and designs.
+
+Distributed deployments across heterogeneous infrastructure are increasingly
+common for cloud native applications.
+Without common ways to programatically ensure consistent policy,
+it is increasingly difficult to evaluate system architecture security at scale.
+Emerging common architectural patterns offer the opportunity
+improve overall security in cloud native systems.
+
+## Focus
+
+In addition to the [CNCF security-related projects](https://github.com/cncf/sig-security/blob/master/governance/cncf-projects.md), there
+are three key focus areas:
+* Protection of heterogeneous, distributed and fast changing systems, while
+providing needed access
+* Common understanding and common tooling to help developers meet security
+requirements
+* Common tooling for audit and reasoning about system properties.
+
+
+### In scope
+
+Terminology note: SIG-Security uses the term "end user" to describe the humans
+who use cloud native applications, whereas CNCF refers to companies that operate
+cloud native systems as CNCF End Users. In the context of security, we often
+need to discuss how a particular control affects the people who use the software
+deployed by a company or organization.
+
+When we use the word "security" within this group, it is defined to be inclusive
+of concerns that affect the integrity of the a cloud native
+system or the privacy of its users,  specifically how to enable secure
+access, policy control and safety for operators, administrators,
+developers, and end-users  across the cloud native ecosystem.
+
+SIG-Security will consider [proposals](https://github.com/cncf/sig-security/blob/master/governance/process.md) from its members or delegated
+tasks from the CNCF TOC that are consistent with the mission, including
+the following activities:
+
+* Publish educational resources on cloud native security
+  * Videos and/or slides from invited presentations by security providers and use cases
+  * Answer the following questions (referring to already existing resources where possible):
+      * What is different about cloud security? (including hybrid and multi-cloud)
+      * What are effective practices for implementing policy controls?
+      * How can we test, validate, explain, audit our systems?
+      * What additional measures are needed, specific to cloud, in highly regulated environments?
+  * Personas and use cases
+  * Common vocabulary to talk about and understand cloud native security
+  * CNCF project ecosystem & landscape
+  * Define security scenarios (e.g. network configuration, application security, service orchestration)
+  * Block architecture(s) for secure access
+  * Highlight trade-offs (e.g. Expressibility vs Explainability)
+  * Best practices and anti-patterns (potentially highlighting where there is disagreement on these)
+* Security assessments of specific proposals or projects
+* Identify projects for consideration for CNCF
+* Cross-pollinate knowledge by participating and inviting people from other projects and SIGs to share security practices
+* Integrate relevant external standards, such as from CII or NIST, as part of educational resources and/or SIG processes
+
+Given that the group is comprised of volunteers, specific requests from the TOC
+may be queued according to the bandwidth of the group. The co-chairs will
+facilitate prioritization under the guidance of the SIG-Security TOC liaison.
+
+### Out of scope
+* Not a standards body: We won't be creating standards.
+* Not an umbrella organization: We interact with other groups for knowledge
+  sharing, not decision-making.
+* Not a compliance body
+* Not a certification board for security of individual projects
+* We will not
+  * answer any specific questions regarding the state of security of any project
+    or product
+  * consider device security unless there is some impact to cloud systems.
+  * explore trust and safety concerns that are not specific to cloud
+    (e.g. fraud detection, user generated content moderation, spam filtering,
+    phishing, cross-site scripting attacks, SQL injection, etc.)
+* We will not ensure the safety of any operational system.
+* This is not related to vulnerability detection and handling any specific
+  security vulnerability or attack.
+
+## Governance
+
+Security must be addressed at all levels of the stack and across the whole
+ecosystem, so the group seeks to encourage participation and membership across
+a wide range of roles, from diverse companies and organizations.
+
+### Cross-group relationships
+To focus our efforts, we avoid duplication by developing relationships with
+other groups that
+focus on a particular technology (such as Kubernetes SIGs) or have a broader
+mandate (such as government organizations).
+
+As a guide to visitors, we maintain the list of groups in the SIG
+[README](https://github.com/cncf/sig-security#related-groups).
+
+Co-chairs are responsible to ensure periodic cross-group knowledge sharing,
+which is accomplished by cross-group membership, invitation to present at
+a SIG meeting and/or offering to present to the related group.
+
+## Operations
+SIG-Security operations are consistent with standard SIG operating guidelines
+provided by the CNCF Technical Oversight Committee
+[TOC](https://github.com/cncf/toc).
+
+Full details of process and roles are linked in the SIG Security [governance README](https://github.com/cncf/sig-security/tree/master/governance).

--- a/sigs/security.md
+++ b/sigs/security.md
@@ -1,6 +1,6 @@
 # CNCF SIG-Security: Special Interest Group on Security
 
-* [Charter](https://github.com/cncf/sig-security/blob/master/governance/charter.md) - reviewed by and contributed to by Jeyappragash JJ, Sarah Allen,
+* [Charter](security-charter.md) - reviewed by and contributed to by Jeyappragash JJ, Sarah Allen,
 Dan Shaw, Brandon Lum, with additional contributions by Alexis Richardson,
 Quinton Hoole and members of SIG-Security (formerly known as SAFE WG), with
 final review by Liz Rice, Joe Beda and Zhipeng Huang.
@@ -10,7 +10,7 @@ final review by Liz Rice, Joe Beda and Zhipeng Huang.
 
 **TOC Liaisons:** [Liz Rice](https://github.com/lizrice), [Justin Cormack](https://github.com/justincormack)
 
-**SIG Chairs:** [Sarah Allen](https://github.com/ultrasaurus), [Dan Shaw](https://github.com/dshaw), [Jeyappragash JJ](https://github.com/pragashj)
+**SIG Chairs:** [Sarah Allen](https://github.com/ultrasaurus), [Emily Fox](https://github.com/TheFoxAtWork), [Jeyappragash JJ](https://github.com/pragashj)
 
 **Tech Leads:** TBD (co-chairs to act as tech leads until at least two Technical Leads are identified, see [roles](https://github.com/cncf/sig-security/blob/master/governance/roles.md#role-of-chairs))
 

--- a/sigs/security.md
+++ b/sigs/security.md
@@ -12,6 +12,11 @@ final review by Liz Rice, Joe Beda and Zhipeng Huang.
 
 **SIG Chairs:** [Sarah Allen](https://github.com/ultrasaurus), [Emily Fox](https://github.com/TheFoxAtWork), [Jeyappragash JJ](https://github.com/pragashj)
 
-**Tech Leads:** TBD (co-chairs to act as tech leads until at least two Technical Leads are identified, see [roles](https://github.com/cncf/sig-security/blob/master/governance/roles.md#role-of-chairs))
+**Tech Leads:** 
+* Brandon Lum ([@lumjjb](https://github.com/lumjjb)), IBM
+* Justin Cappos ([@JustinCappos](https://github.com/JustinCappos)), New York University
+* Ash Narkar ([@ashutosh-narkar](https://github.com/ashutosh-narkar)), Styra
+* Andres Vega ([@anvega](https://github.com/anvega), VMWare
+* Aradhana Chetal ([@achetal01](https://github.com/achetal01), TIAA 
 
 For complete details on process and elaboration of rules, see [SIG-Security governance](https://github.com/cncf/sig-security/tree/master/governance)

--- a/sigs/storage-charter.md
+++ b/sigs/storage-charter.md
@@ -116,10 +116,10 @@ This SIG follows the [standard operating
 guidelines](https://github.com/cncf/toc/blob/main/sigs/cncf-sigs.md#operating-model)
 provided by the TOC unless otherwise stated here.
 
-**TOC Liaison:** [Xiang Li](https://github.com/xiang90)
+**TOC Liaison:** [Erin Boyd](https://github.com/erinboyd), [Saad Ali](https://github.com/saad-ali)
 
-**SIG Chairs:** [Alex Chircop](https://github.com/chira001), [Quinton Hoole](https://github.com/quinton-hoole), [Erin Boyd](https://github.com/erinboyd)
+**SIG Chairs:** [Alex Chircop](https://github.com/chira001), [Quinton Hoole](https://github.com/quinton-hoole)
 
-**Tech Leads:** Saad Ali, Xing Yang, Sugu Sougoumarane, Luis Pabon
+**Tech Leads:** Xing Yang, Sugu Sougoumarane, Luis Pabon
 
 **Other named roles: **None at present; will be identified and staffed as needed.


### PR DESCRIPTION
* Updates: App-Delivery, Contrib-Strat (added charter), Network, Runtime, Observability, Security (added charter), Storage

Resolves: https://github.com/cncf/toc/issues/538
Resolves: https://github.com/cncf/toc/issues/418
Resolves: https://github.com/cncf/toc/issues/404 