### PR TITLE
Add Carolyn Van Slyck as Tech Lead for TAG-Contributor Strategy

### DIFF
--- a/tags/contributor-strategy.md
+++ b/tags/contributor-strategy.md
@@ -136,8 +136,7 @@ Members who are no longer participating actively in the TAG (including both WG
 - TOC Liaison: Saad Ali, Alena Prokharchyk  
 - Chairs: Josh Berkus, Stephen Augustus, Paris Pittman  (Emeritus: Gerred 
 Dillon)
-- Tech Leads: None at this time but can change with need at a later time with
-charter ratification   
+- Tech Leads: Carolyn Van Slyck
 
 In accordance with the terms and roles laid out in [cncf-tags.md](https://github.com/cncf/toc/blob/master/tags/cncf-tags.md)
 


### PR DESCRIPTION
As the owner and approver of the new contribute.cncf.io website, Carolyn is now our de-facto Tech Lead, so it is about time that she be recognized as such.

Already approved by @parispittman and @justaugustus.

Please approve, @alena1108 and @saad-ali 