### PR TITLE
fix(process): Removes PR step for sandbox projects

### DIFF
--- a/process/project_proposals.adoc
+++ b/process/project_proposals.adoc
@@ -17,7 +17,6 @@ All exceptions (and "no" outcomes) are handled by the TOC. Possible "no" outcome
 image::sandbox-process.png[Sandbox process]
 . *Project Proposal*
    * Project proposed through a https://docs.google.com/forms/d/1bJhG1MuM981uQXcnBMv4Mj9yfV5_q5Kwk3qhBCLa_5A/edit[form]
-   * Project proposed for contribution through a https://github.com/cncf/toc/pulls[Pull request] 
 . *TOC Review*
    * TOC reviews proposal in spreadsheet and presentation, project passes for inclusion with a simple majority vote. 
    * TOC may engage with project to ask further questions


### PR DESCRIPTION
I found out in #664 that you only need to submit the form and not a PR.
However, it does seem like the sandbox diagram and the documentation have
drifted out of sync with each other and I wasn't sure enough of the
process to update that