### PR TITLE
Proposal for streamlined graduation process

### DIFF
--- a/.github/ISSUE_TEMPLATE/graduation.md
+++ b/.github/ISSUE_TEMPLATE/graduation.md
@@ -32,4 +32,3 @@
 
 \[INSERT: grass roots? adopters?\]
 
-[What do your enemies say too?\]

--- a/.github/ISSUE_TEMPLATE/graduation.md
+++ b/.github/ISSUE_TEMPLATE/graduation.md
@@ -1,0 +1,35 @@
+# Application for Graduation
+- [ ] Have committers from at least two organizations.
+- [ ] Have achieved and maintained a Core Infrastructure Initiative Best Practices Badge.
+- [ ] Have completed an independent and third party security audit with results published of similar scope and quality as this example which includes all critical vulnerabilities and all critical vulnerabilities need to be addressed before graduation.
+- [ ] Explicitly define a project governance and committer process. This preferably is laid out in a GOVERNANCE.md file and references an OWNERS.md file showing the current and emeritus committers.
+- [ ] Have a public list of project adopters for at least the primary repo (e.g., ADOPTERS.md or logos on the project website). For a specification, have a list of adopters for the implementation(s) of the spec.
+
+
+## About your Project
+
+\[INSERT: Project name]
+\
+[INSERT: Link to project website with summary of what the project does] 
+
+[INSERT: Link to GitHub repo] 
+
+[INSERT: Link to Incubation doc]
+
+## Why is the Project is ready to Graduate? 
+
+\[INSERT: ]
+
+## What has changed since you joined Incubation? 
+
+\[INSERT: new processes / governance? end user adoption? community size? Feature stability?]
+
+## How can your project survive its founders and founding companies?
+
+\[INSERT: setting yourself up for the long run\]
+
+## Who are the best advocates for your project? What do they say?
+
+\[INSERT: grass roots? adopters?\]
+
+[What do your enemies say too?\]

--- a/process/README.md
+++ b/process/README.md
@@ -76,7 +76,7 @@ Projects currently in progress for consideration at the Incubating stage are tra
 Projects that wish to move from Incubating to Graduation should open a PR confirming the following criteria: 
 * Have committers from at least two organizations.
 * Have achieved and maintained a [Core Infrastructure Initiative Best Practices Badge](https://bestpractices.coreinfrastructure.org/).
-* Have completed an independent and third party security audit with results published of similar scope and quality as this example which includes all critical vulnerabilities and all critical vulnerabilities need to be addressed before graduation.
+* Have completed an independent and third party security audit with results published of similar scope and quality as [this example](https://github.com/envoyproxy/envoy#security-audit) which includes all critical vulnerabilities and all critical vulnerabilities need to be addressed before graduation.
 * Explicitly define a project governance and committer process. This preferably is laid out in a GOVERNANCE.md file and references an OWNERS.md file showing the current and emeritus committers.
 * Have a public list of project adopters for at least the primary repo (e.g., ADOPTERS.md or logos on the project website). For a specification, have a list of adopters for the implementation(s) of the spec.
 * Please include a short one-page narrative based off the Graduation template, no more than 500 words.

--- a/process/README.md
+++ b/process/README.md
@@ -73,12 +73,13 @@ To be accepted to incubating stage, a project must meet the sandbox stage requir
 Projects currently in progress for consideration at the Incubating stage are tracked: https://github.com/cncf/toc/projects/7 
 
 ## (3) Project Graduation Process: Incubating to Graduation 
-Projects that wish to move from Incubating to Graduation: 
+Projects that wish to move from Incubating to Graduation should open a PR confirming the following criteria: 
 * Have committers from at least two organizations.
 * Have achieved and maintained a [Core Infrastructure Initiative Best Practices Badge](https://bestpractices.coreinfrastructure.org/).
 * Have completed an independent and third party security audit with results published of similar scope and quality as this example which includes all critical vulnerabilities and all critical vulnerabilities need to be addressed before graduation.
 * Explicitly define a project governance and committer process. This preferably is laid out in a GOVERNANCE.md file and references an OWNERS.md file showing the current and emeritus committers.
 * Have a public list of project adopters for at least the primary repo (e.g., ADOPTERS.md or logos on the project website). For a specification, have a list of adopters for the implementation(s) of the spec.
+* Please include a short one-page narrative based off the Graduation template, no more than 500 words.
 
 Projects moving from incubation to graduation are tracked here: https://github.com/cncf/toc/projects/6
 

--- a/process/graduation-proposal-template.md
+++ b/process/graduation-proposal-template.md
@@ -11,9 +11,9 @@ _**Project should address each graduation criteria listed below**_
 
 ### * Have completed an independent and third party security audit with results published of similar scope and quality as [this example](https://github.com/envoyproxy/envoy#security-audit) which includes all critical vulnerabilities and all critical vulnerabilities need to be addressed before graduation.
 
-### * Explicitly define a project governance and committer process. This preferably is laid out in a GOVERNANCE.md file and references an OWNERS.md file showing the current and emeritus committers.
+### * Explicitly define a Project governance and committer process. This preferably is laid out in a GOVERNANCE.md file and references an OWNERS.md file showing the current and emeritus committers.
 
-### * Have a public list of project adopters for at least the primary repo (e.g., ADOPTERS.md or logos on the project website). For a specification, have a list of adopters for the implementation(s) of the spec.
+### * Have a public list of Project adopters for at least the primary repo (e.g., ADOPTERS.md or logos on the Project website). For a specification, have a list of adopters for the implementation(s) of the spec.
 
 ## Incubation Details
 _**Project should address each area listed below**_

--- a/process/project_proposals.adoc
+++ b/process/project_proposals.adoc
@@ -71,10 +71,13 @@ image::incubation-process.png[Incubation process]
    * Project fills out and submits the link:graduation-proposal-template.md[graduation proposal template] in a pull request in the https://github.com/cncf/toc[cncf/toc GitHub repo].
    * The file containing the proposal should be located in https://github.com/cncf/toc/tree/main/proposals/graduation[the graduation proposals directory].
    * The proposal addresses how the project has grown since incubation and any concerns from incubation DD in addition to the standard graduation requirements.
-. *TOC member kicks off two week period of time for public comment on the TOC mailing list*
+   * Projects will be reviewed on a rolling basis as they apply, instead of two meetings a year.    
+. * If a TOC member steps forward to support the project as a sponsor, the TOC member kicks off two week period of time for public comment on the TOC mailing list
    * The email should contain a link to the proposal pull request and incubation DD document.
    * All TAGs, end users, TOC members, and community members are welcome to comment at this time on the mailing list.
-   * Historically, projects have done a TOC presentation as part of the graduation process. The TOC has gotten rid of the presentation requirement. Instead, if the TOC wants to have a deeper discussion about the project with the maintainers, they may schedule an ad hoc meeting to do so before the vote.
+   * Historically, projects have done a TOC presentation as part of the graduation process. The TOC has gotten rid of the presentation requirement. 
+* If the TOC does not sponsor the project to move forward at that time, they will provide feedback to the project and the PR will be closed. 
+
 . *TOC vote*
    * TOC members assess whether project meets the https://github.com/cncf/toc/blob/main/process/graduation_criteria.adoc#graduation-stage[Graduation criteria]
    * Projects must have a 2/3 supermajority vote of the TOC to graduate


### PR DESCRIPTION
This PR adds a graduation template for pull requests for projects wanting to move from incubation to graduation. 

Problem Statement: projects are having a hard time finding TOC sponsors. Lobbying individual sponsors is not scaling up.
Goal: Give projects more clarity and provide a framework for giving a project feedback on what the TOC would want them to address before they get started with their graduation process. 

This includes a One-Pager to advocate project to the TOC members, as we need a forum for projects to nominate themselves and give their pitch to the TOC.

The process will change from the current process of submitting a PR and asking for a TOC sponsor to move forward, to a more streamlined process at the time that this PR passes a TOC vote. Projects applying for graduation that do not yet have a TOC sponsor will be moved to this process at the time of an approved vote. 
 
Projects will be reviewed on a rolling basis as they apply, instead of two meetings a year. 
