### PR TITLE
Proposal to archive OpenTracing

### DIFF
--- a/docs/PROJECTS.csv
+++ b/docs/PROJECTS.csv
@@ -1,7 +1,7 @@
 Project,Sponsor,TOC Presentation,Accepted,Stage,Logo on CNCF website,CLA,Governance,Security Disclosure,Security Audit,CoC,Slack,GitHub URL
 Kubernetes,Alexis Richardson,N/A,3/10/16,Graduation,Yes,CLA,Yes,Yes,Now on third,Yes,https://kubernetes.slack.com/,https://github.com/kubernetes
 Prometheus,Alexis Richardson,3/4/16,5/9/16,Graduation,Yes,DCO,Yes,Yes,"Yes, cure53",Yes,IRC,https://github.com/prometheus
-OpenTracing,Bryan Cantrill,8/17/16,10/11/16,Incubation,Yes,No,Yes,No,No,Yes,CNCF,https://github.com/opentracing
+OpenTracing,Bryan Cantrill,8/17/16,10/11/16,Archived,Yes,No,Yes,No,No,Yes,CNCF,https://github.com/opentracing
 Fluentd,Brian Grant,8/3/16,11/8/16,Graduation,Yes,DCO,Yes,No,No,Yes,https://slack.fluentd.org/,https://github.com/fluent
 Linkerd,Jonathan Boulle,10/5/16,1/23/17,Incubation,Yes,DCO,Yes,No,No,Yes,https://linkerd.slack.com/,https://github.com/linkerd
 gRPC,Brian Grant,10/19/16,2/16/17,Incubation,Yes,CLA,Yes,No,No,Yes,https://gitter.im/grpc/grpc,https://github.com/grpc

--- a/docs/projects.md
+++ b/docs/projects.md
@@ -4,7 +4,7 @@
 :-----:|:-----:|:-----:|:-----:|:-----:
 [Kubernetes](https://kubernetes.io/)|Alexis Richardson|N/A|[3/10/16](https://cncf.io/news/news/2015/07/techcrunch-kubernetes-hits-10-google-donates-technology-newly-formed-cloud-native)|Graduated
 [Prometheus](https://prometheus.io/)|Alexis Richardson|[3/4/16](https://docs.google.com/presentation/d/1GtVX-ppI95LhrijprGENsrpq78-I1ttcSWLzMVk5d8M/edit?usp=sharing)|[5/9/16](https://cncf.io/news/announcement/2016/05/cloud-native-computing-foundation-accepts-prometheus-second-hosted-project)|Graduated
-[OpenTracing](http://opentracing.io/)|Bryan Cantrill|[8/17/16](https://docs.google.com/presentation/d/1kQkmJtT0bjSRvUTP5YFTKaXSfIM3aL7zxja_KtZtbgw/edit#slide=id.g15fc45ec1a_0_165)|[10/11/16](https://cncf.io/news/blogs/2016/10/opentracing-joins-cloud-native-computing-foundation)|Incubating
+[OpenTracing](http://opentracing.io/)|Bryan Cantrill|[8/17/16](https://docs.google.com/presentation/d/1kQkmJtT0bjSRvUTP5YFTKaXSfIM3aL7zxja_KtZtbgw/edit#slide=id.g15fc45ec1a_0_165)|[10/11/16](https://cncf.io/news/blogs/2016/10/opentracing-joins-cloud-native-computing-foundation)|Archived
 [Fluentd](http://www.fluentd.org/)|Brian Grant|[8/3/16](https://docs.google.com/presentation/d/1S79MNv3E2aG8nuZJFJ0XMSumf7jnKozN3vdrivCH77U/edit?usp=sharing)|[11/8/16](https://www.cncf.io/blog/2016/12/08/fluentd-cloud-native-logging)|Graduated
 [Linkerd](https://linkerd.io/)|Jonathan Boulle|[10/5/16](https://docs.google.com/presentation/d/19aamsOR__zGFNNFCmid2TjaJwEqNOXmHRa34EQwf3sA/edit#slide=id.g181e6fdb33_0_0)|[1/23/17](https://www.cncf.io/blog/2017/01/23/linkerd-project-joins-cloud-native-computing-foundation)|Incubating
 [gRPC](http://www.grpc.io/)|Brian Grant|[10/19/16](https://docs.google.com/presentation/d/16mNYaqgd7BaV50OnbcuQ1zRHpWoUKhL3XHvCJwEm8CE/edit#slide=id.g185c09339a_23_106)|[2/16/17](https://www.cncf.io/blog/2017/03/01/cloud-native-computing-foundation-host-grpc-google)|Incubating
@@ -183,3 +183,4 @@
 **Project**|**Sponsor**|**TOC Deck**|**Archived**|**Maturity Level**
 :-----:|:-----:|:-----:|:-----:|:-----:
 [rkt](http://rkt.io)|Brian Grant|[3/15/17](https://docs.google.com/presentation/d/1KzA58_Zz30mKKzeLuSvXLh63aIC75KRdAOTw4PJ_10g/edit?usp=sharing)|[8/16/19](https://www.cncf.io/blog/2019/08/16/cncf-archives-the-rkt-project/)|Archived
+[OpenTracing](http://opentracing.io/)|Bryan Cantrill|[8/17/16](https://docs.google.com/presentation/d/1kQkmJtT0bjSRvUTP5YFTKaXSfIM3aL7zxja_KtZtbgw/edit#slide=id.g15fc45ec1a_0_165)|[10/11/16](https://cncf.io/news/blogs/2016/10/opentracing-joins-cloud-native-computing-foundation)|Archived


### PR DESCRIPTION
Since the merger of OpenTracing & OpenCensus into OpenTelemetry it was always the maintainers’ intention to archive OpenTracing. Now that OTel has reached incubation, OpenTracing is proposed as an archived project as the previous iteration of OpenTelemetry.   

Archiving a project is rare, this is only the 2nd CNCF project to be archived. https://github.com/cncf/toc/blob/master/process/archiving.md has details but what this means:  


- CNCF will no longer provide support for the project via service desk
- CNCF will list archived projects online
- Trademarks and domain names of archived projects are still hosted neutrally by the CNCF and the Linux Foundation
- CNCF can provide services such as documentation updates to help transition users.
- Other CNCF marketing activities will no longer be provided for the project (like space at conferences)
