### PR TITLE
Slack migration guidelines added

### DIFF
--- a/.github/ISSUE_TEMPLATE/project-onboarding.md
+++ b/.github/ISSUE_TEMPLATE/project-onboarding.md
@@ -4,29 +4,30 @@ about: project onboarding
 title: "[SANDBOX PROJECT ONBOARDING] project"
 labels: project onboarding, sandbox
 assignees: caniszczyk, amye, idvoretskyi
-
 ---
 
 Welcome to CNCF Project Onboarding!
-This is an issue created to help onboard your project into the CNCF after the TOC has voted to accept your project. 
-We would like to complete onboarding within one month of acceptance. 
+This is an issue created to help onboard your project into the CNCF after the TOC has voted to accept your project.
+We would like to complete onboarding within one month of acceptance.
 
 From the project side, please ensure that you:
+
 - [ ] Understand the project proposal process and reqs: https://github.com/cncf/toc/blob/main/process/project_proposals.adoc#introduction
 - [ ] Understand the services available for your project at CNCF https://www.cncf.io/services-for-projects/
 - [ ] Ensure your project meets the CNCF IP Policy: https://github.com/cncf/foundation/blob/master/charter.md#11-ip-policy
 - [ ] Review the online programs guidelines: https://github.com/cncf/foundation/blob/master/online-programs-guidelines.md
-- [ ] Understand the trademark guidelines: https://www.linuxfoundation.org/en/trademark-usage/ 
+- [ ] Understand the trademark guidelines: https://www.linuxfoundation.org/en/trademark-usage/
 - [ ] Understand the license allowlist: https://github.com/cncf/foundation/blob/master/allowed-third-party-license-policy.md#approved-licenses-for-allowlist
 - [ ] Has your project adopted open governance already? see http://opengovernance.dev
-- [ ] Slack: Are your slack channels migrated to the Kubernetes or CNCF Slack? 
-- [ ] Is your project in its own separate neutral github organization? 
+- [ ] Slack: Are your slack channels migrated to the Kubernetes or CNCF Slack? (see https://slack.com/help/articles/217872578-Import-data-from-one-Slack-workspace-to-another for more details)
+- [ ] Is your project in its own separate neutral github organization?
 - [ ] Submitted a Pull request to add your project as a sandbox project to https://landscape.cncf.io
 - [ ] Create maintainer list + add to aggregated https://maintainers.cncf.io list by submitting a PR to it
-- [ ] Have added your project to https://github.com/cncf/contribute 
+- [ ] Have added your project to https://github.com/cncf/contribute
 - [ ] Artwork: Submit a pull request to https://github.com/cncf/artwork with your artwork
 
-Things that CNCF will need from the project: 
+Things that CNCF will need from the project:
+
 - [ ] Provide emails for the maintainers added to https://maintainers.cncf.io in order to get access to the maintainers mailing list and ServiceDesk
 - [ ] Domain: transfer domain to the CNCF - please send a transfer code to project-onboarding@cncf.io
 - [ ] Trademarks: transfer any trademark and logo mark assets over to the LF - https://github.com/cncf/foundation/tree/master/agreements has agreements
@@ -36,11 +37,12 @@ Things that CNCF will need from the project:
 - [ ] Website: Analytics transferred to amye@linuxfoundation.org
 - [ ] CII: Start on a CII best practices badge https://bestpractices.coreinfrastructure.org/en
 
-Things that the CNCF will do or help the project to do: 
+Things that the CNCF will do or help the project to do:
+
 - [ ] Devstats: add to devstats https://devstats.cncf.io/
 - [ ] Marketing: update relevant intro + slide decks
 - [ ] Events: update CFP + Registration + CFP Area forms
 - [ ] ServiceDesk: confirm maintainers have read https://www.cncf.io/services-for-projects/
 - [ ] CNCF Welcome Email Sent to confirm maintainer list access, welcome email has monthly project sync details
-- [ ] Create space for meetings/events on https://community.cncf.io, e.g., https://community.cncf.io/pravega-community/ -  (https://github.com/cncf/communitygroups/blob/main/README.md#cncf-projects)
+- [ ] Create space for meetings/events on https://community.cncf.io, e.g., https://community.cncf.io/pravega-community/ - (https://github.com/cncf/communitygroups/blob/main/README.md#cncf-projects)
 - [ ] Adopt a license scanning tool, like FOSSA or Snyk


### PR DESCRIPTION
Slack migration guidelines added to the onboarding document - https://slack.com/help/articles/217872578-Import-data-from-one-Slack-workspace-to-another

cc @amye 