### PR TITLE
Chair and TL updates to tags/security.md

### DIFF
--- a/tags/security.md
+++ b/tags/security.md
@@ -1,20 +1,21 @@
-# CNCF TAG-Security: Special Interest Group on Security
+# CNCF TAG-Security: Technical Advisory Group on Security
 
 * [Charter](security-charter.md) - reviewed by and contributed to by Jeyappragash JJ, Sarah Allen,
 Dan Shaw, Brandon Lum, with additional contributions by Alexis Richardson,
 Quinton Hoole and members of TAG-Security (formerly known as SAFE WG), with
 final review by Liz Rice, Joe Beda and Zhipeng Huang.
-* [Current CNCF Projects](https://github.com/cncf/tag-security/blob/master/governance/cncf-projects.md)
+* [Current CNCF Projects](https://github.com/cncf/tag-security/blob/main/governance/cncf-projects.md)
 
 ## **Operations**
 
-**TOC Liaisons:** [Liz Rice](https://github.com/lizrice), [Justin Cormack](https://github.com/justincormack)
+**TOC Liaisons:** [Justin Cormack](https://github.com/justincormack)
 
-**TAG Chairs:** [Brandon Lum](https://github.com/lumjjb), [Emily Fox](https://github.com/TheFoxAtWork), [Aradhana Chetal](https://github.com/achetal01)
+**TAG Chairs:** [Brandon Lum](https://github.com/lumjjb), [Aradhana Chetal](https://github.com/achetal01)
 
 **Tech Leads:** 
 * Justin Cappos ([@JustinCappos](https://github.com/JustinCappos)), New York University
 * Ash Narkar ([@ashutosh-narkar](https://github.com/ashutosh-narkar)), Styra
-* Andres Vega ([@anvega](https://github.com/anvega), VMWare
+* Andres Vega ([@anvega](https://github.com/anvega), VMware
+* Pushkar Joglekar ([@pushkarj](https://github.com/pushkarj), VMware
 
-For complete details on process and elaboration of rules, see [TAG-Security governance](https://github.com/cncf/tag-security/tree/master/governance)
+For complete details on process and elaboration of rules, see [TAG-Security governance](https://github.com/cncf/tag-security/tree/main/governance)


### PR DESCRIPTION
## Summary
- Updated chairs, liaisons and TLs
- Renamed master to main branch
- Rename Special Interest Group to Technical Advisory Group

Note: Happy to hold this for merge, until Security Liaison replacing Liz is decided!

/cc @TheFoxAtWork

Related issues: https://github.com/cncf/tag-security/issues/857 and https://github.com/cncf/tag-security/pull/846