### PR TITLE
What: Clarify existing sentiment around Graduation DD document

### DIFF
--- a/process/project_proposals.adoc
+++ b/process/project_proposals.adoc
@@ -72,11 +72,12 @@ image::incubation-process.png[Incubation process]
    * The file containing the proposal should be located in https://github.com/cncf/toc/tree/main/proposals/graduation[the graduation proposals directory].
    * The proposal addresses how the project has grown since incubation and any concerns from incubation DD in addition to the standard graduation requirements.
    * Projects will be reviewed on a rolling basis as they apply, instead of two meetings a year.    
-. * If a TOC member steps forward to support the project as a sponsor and the DD document is finalized, the TOC member kicks off two week period of time for public comment on the TOC mailing list
+. * If a TOC member steps forward to support the project as a sponsor and the Graduation DD document is finalized or the previous DD document is within 1 year with no significant changes, the TOC member kicks off two week period of time for public comment on the TOC mailing list
    * The email should contain a link to the proposal pull request and incubation DD document.
    * All TAGs, end users, TOC members, and community members are welcome to comment at this time on the mailing list.
    * Historically, projects have done a TOC presentation as part of the graduation process. The TOC has gotten rid of the presentation requirement. 
 * If the TOC does not sponsor the project to move forward at that time, they will provide feedback to the project and the PR will be closed. 
+* If the Graduation DD document is not finalized, the TOC sponsor will begin the process to refresh the existing DD document and begin the public comment process.
 
 . *TOC vote*
    * TOC members assess whether project meets the https://github.com/cncf/toc/blob/main/process/graduation_criteria.adoc#graduation-stage[Graduation criteria]

--- a/process/project_proposals.adoc
+++ b/process/project_proposals.adoc
@@ -72,7 +72,7 @@ image::incubation-process.png[Incubation process]
    * The file containing the proposal should be located in https://github.com/cncf/toc/tree/main/proposals/graduation[the graduation proposals directory].
    * The proposal addresses how the project has grown since incubation and any concerns from incubation DD in addition to the standard graduation requirements.
    * Projects will be reviewed on a rolling basis as they apply, instead of two meetings a year.    
-. * If a TOC member steps forward to support the project as a sponsor and the Graduation DD document is finalized or the previous DD document is within 1 year with no significant changes, the TOC member kicks off two week period of time for public comment on the TOC mailing list
+. * If a TOC member steps forward to support the project as a sponsor and determines the Graduation DD document is finalized, the TOC member kicks off two week period of time for public comment on the TOC mailing list
    * The email should contain a link to the proposal pull request and incubation DD document.
    * All TAGs, end users, TOC members, and community members are welcome to comment at this time on the mailing list.
    * Historically, projects have done a TOC presentation as part of the graduation process. The TOC has gotten rid of the presentation requirement. 


### PR DESCRIPTION
Why:

* lack of clarity and expectations for projects and TOC members in the existing language.

This change addresses the need by:

* Provided clear process-oriented expansion of existing instructions to match actual activities.