### PR TITLE
Fix markdown links

### DIFF
--- a/process/graduation_criteria.md
+++ b/process/graduation_criteria.md
@@ -2,28 +2,28 @@
 
 Every CNCF project has an associated maturity level. Proposed CNCF projects should state their preferred maturity level. A two-thirds supermajority is required for a project to be accepted as incubating or graduated. If there is not a supermajority of votes to enter as a graduated project, then any graduated votes are recounted as votes to enter as an incubating project. If there is not a supermajority of votes to enter as an incubating project, then any graduated or incubating votes are recounted as sponsorship to enter as an sandbox project. If there is not enough sponsorship to enter as an sandbox stage project, the project is rejected. This voting process is called fallback voting.
 
-The criteria for each stage of maturity are described below, and there is a separate [https://github.com/cncf/toc/blob/main/process/project_proposals.md](Project Proposal process).
+The criteria for each stage of maturity are described below, and there is a separate [Project Proposal process](https://github.com/cncf/toc/blob/main/process/project_proposals.md).
 
-Incubating and graduated projects have access to all resources listed at [https://cncf.io/projects](https://cncf.io/projects) but if there is contention, more mature projects will generally have priority.
+Incubating and graduated projects have access to all resources listed at [cncf.io/projects](https://cncf.io/projects) but if there is contention, more mature projects will generally have priority.
 
 ### Sandbox Stage
 
 To be accepted in the sandbox a project must
 
-* Apply to join the sandbox using the [https://docs.google.com/forms/d/1bJhG1MuM981uQXcnBMv4Mj9yfV5_q5Kwk3qhBCLa_5A/edit](form)
-* Adopt the CNCF [https://github.com/cncf/foundation/blob/master/code-of-conduct.md](Code of Conduct)
-* Adhere to CNCF [https://github.com/cncf/foundation/blob/master/charter.md#11-ip-policy](IP Policy) (including trademark transferred)
+* Apply to join the sandbox using the [form](https://docs.google.com/forms/d/1bJhG1MuM981uQXcnBMv4Mj9yfV5_q5Kwk3qhBCLa_5A/edit)
+* Adopt the CNCF [Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md)
+* Adhere to CNCF [IP Policy](https://github.com/cncf/foundation/blob/master/charter.md#11-ip-policy) (including trademark transferred)
 * List their sandbox status prominently on website/readme
 
-See the [https://github.com/cncf/toc/blob/main/process/sandbox.md][CNCF Sandbox Guidelines v1.0] for the detailed process.
+See the [CNCF Sandbox Guidelines v1.0](https://github.com/cncf/toc/blob/main/process/sandbox.md) for the detailed process.
 
 ### Incubating Stage
 
-*Note: The incubation level is the point at which we expect to perform full [https://github.com/cncf/toc/blob/main/process/due-diligence-guidelines.md](due diligence) on projects.*
+*Note: The incubation level is the point at which we expect to perform full [due dilligence](https://github.com/cncf/toc/blob/main/process/due-diligence-guidelines.md) on projects.*
 
 To be accepted to incubating stage, a project must meet the sandbox stage requirements plus:
 
- * Document that it is being used successfully in production by at least three independent end users which, in the TOC’s judgement, are of adequate quality and scope. For the definition of an end user, see https://github.com/cncf/toc/blob/main/FAQ.md#what-is-the-definition-of-an-end-user
+ * Document that it is being used successfully in production by at least three independent end users which, in the TOC’s judgement, are of adequate quality and scope. For the definition of an end user, see https://github.com/cncf/toc/blob/main/FAQ.md#what-is-the-definition-of-an-end-user.
 
  * Have a healthy number of committers. A committer is defined as someone with the commit bit; i.e., someone who can accept contributions to some or all of the project.
  * Demonstrate a substantial ongoing flow of commits and merged contributions.
@@ -37,7 +37,7 @@ To be accepted to incubating stage, a project must meet the sandbox stage requir
 To graduate from sandbox or incubating status, or for a new project to join as a graduated project, a project must meet the incubating stage criteria plus:
 
  * Have committers from at least two organizations.
- * Have achieved and maintained a Core Infrastructure Initiative [https://bestpractices.coreinfrastructure.org/](Best Practices Badge).
+ * Have achieved and maintained a Core Infrastructure Initiative [Best Practices Badge](https://bestpractices.coreinfrastructure.org/).
  * Have completed an independent and third party security audit with results published of similar scope and quality as the following example (including critical vulnerabilities addressed): https://github.com/envoyproxy/envoy#security-audit and all critical vulnerabilities need to be addressed before graduation.
  * Explicitly define a project governance and committer process. This preferably is laid out in a GOVERNANCE.md file and references an OWNERS.md file showing the current and emeritus committers.
  * Have a public list of project adopters for at least the primary repo (e.g., ADOPTERS.md or logos on the project website). For a specification, have a list of adopters for the implementation(s) of the spec.

--- a/process/project_proposals.md
+++ b/process/project_proposals.md
@@ -17,7 +17,7 @@ All exceptions (and "no" outcomes) are handled by the TOC. Possible "no" outcome
 ![Sandbox process](sandbox-process.png)
 
  *Project Proposal*
-   * Project proposed through a [https://docs.google.com/forms/d/1bJhG1MuM981uQXcnBMv4Mj9yfV5_q5Kwk3qhBCLa_5A/edit](form)
+   * Project proposed through a [form](https://docs.google.com/forms/d/1bJhG1MuM981uQXcnBMv4Mj9yfV5_q5Kwk3qhBCLa_5A/edit)
 
  *TOC Review*
    * TOC reviews proposal in spreadsheet and presentation, project passes for inclusion with a simple majority vote. 
@@ -28,23 +28,23 @@ All exceptions (and "no" outcomes) are handled by the TOC. Possible "no" outcome
    * CNCF staff handle governance / legal issues
    * This can happen after TOC Sandbox Sponsors step forward
 
-See the [https://github.com/cncf/toc/blob/main/process/sandbox.md](Sandbox guidelines) for the definition of and motivation behind the CNCF Sandbox.
+See the [Sandbox guidelines](https://github.com/cncf/toc/blob/main/process/sandbox.md) for the definition of and motivation behind the CNCF Sandbox.
 
 ### Incubation process
 
-Note: We have [https://docs.google.com/presentation/d/1J9nti4JdiwLHxY15KtkmqyfP4OgNfrLAd3vxPvFTzsc/edit?usp=sharing](streamlined the Incubation process).
+Note: We have [streamlined the Incubation process](https://docs.google.com/presentation/d/1J9nti4JdiwLHxY15KtkmqyfP4OgNfrLAd3vxPvFTzsc/edit?usp=sharing).
 
 All exceptions (and "no" outcomes) are handled by the TOC.
 
 ![Incubation Process](incubation-process.png)
 
 *Project Proposal* 
-   * Incubation proposed through a [https://github.com/cncf/toc/pulls](GitHub pull request)
+   * Incubation proposed through a [GitHub pull request](https://github.com/cncf/toc/pulls)
    * The proposal moves to Due Diligence when a TOC member steps forward as an Incubation Sponsor.
    * The status of outstanding Incubation proposals is reported on a monthly basis in the TOC public meeting. This highlights projects looking for sponsorship, and provides a check-in on DD progress for sponsored projects. 
    * A potential sponsor can indicate that they are interested but don't have capacity to work on DD at this time, to set a project's expectations.
-   * The TOC may agree that the project does not (yet) meet the [https://github.com/cncf/toc/blob/main/process/graduation_criteria.md#incubation-stage](Incubation requirements) and give feedback on why this is the case. If the project is not already in the CNCF, the TOC may suggest that project apply for Sandbox instead.
-   * If a TOC Incubation Sponsor has not stepped forward within two months after the proposal PR is submitted, projects may request that their project proposal is discussed at a forthcoming TOC meeting by adding it to the [https://docs.google.com/document/d/1jpoKT12jf2jTf-2EJSAl4iTdA7Aoj_uiI19qIaECNFc/edit](Working Doc). The outcome of this is discussion is either that a sponsor steps forward, or that the TOC votes to admit the project to Sandbox, or the proposal is rejected (projects may reapply after six months). If, even after all those steps, a sponsor does not step forward, the proposal is rejected. 
+   * The TOC may agree that the project does not (yet) meet the [Incubation requirements](https://github.com/cncf/toc/blob/main/process/graduation_criteria.md#incubation-stage) and give feedback on why this is the case. If the project is not already in the CNCF, the TOC may suggest that project apply for Sandbox instead.
+   * If a TOC Incubation Sponsor has not stepped forward within two months after the proposal PR is submitted, projects may request that their project proposal is discussed at a forthcoming TOC meeting by adding it to the [Working Doc](https://docs.google.com/document/d/1jpoKT12jf2jTf-2EJSAl4iTdA7Aoj_uiI19qIaECNFc/edit). The outcome of this is discussion is either that a sponsor steps forward, or that the TOC votes to admit the project to Sandbox, or the proposal is rejected (projects may reapply after six months). If, even after all those steps, a sponsor does not step forward, the proposal is rejected. 
    * DD will usually involve a presentation to a TAG, but an interested TAG is welcome to schedule a project presentation at any time. TAGs can discuss their recommendations or concerns about a project with their TOC liaison(s) if there isn't already a TOC Incubation Sponsor in place. 
    * Although it is not necessary, projects are allowed to informally reach out to TOC members for advice, including asking about potential sponsorship. TOC members should keep each other informed about these approaches so that we can avoid falling prey to "lobbying". There is a fine line between a project asking for help to make a successful application, and a project shopping around looking to pressurize a TOC member into sponsorship. 
 
@@ -53,27 +53,27 @@ All exceptions (and "no" outcomes) are handled by the TOC.
    * TOC Incubation Sponsor is a point of contact for the project throughout the process.
    * TOC members may not sponsor a project for which they have a clear conflict of interest (for example, originating primarily from their organization). This doesn't mean that they can't have any involvement at all - for example, contributing pull requests, or being an end user of that project, can signal a healthy interest in and knowledge of a worthwhile project. 
 . *Due Diligence* _2-3 months_
-   * TOC Incubation Sponsor drives due diligence (see the [https://github.com/cncf/toc/blob/main/process/dd-review-template.md](template) and [https://github.com/cncf/toc/blob/main/process/due-diligence-guidelines.md](guidelines)).
+   * TOC Incubation Sponsor drives due diligence (see the [template](https://github.com/cncf/toc/blob/main/process/dd-review-template.md) and [guidelines](https://github.com/cncf/toc/blob/main/process/due-diligence-guidelines.md)).
    * TOC Incubation Sponsor can delegate DD work to CNCF TAGs and/or other TOC members.
    * Typically DD includes a presentation to a CNCF TAG, as identified by the TOC Sponsor. This step may be omitted if the TOC Sponsor feels there are readily-available and suitable presentations on video - for example, because the TAG has already recently held a presentation. (We do not want unnecessary levels of process or bureaucracy to delay a widely-known and adopted project from joining the CNCF). TOC Sponsor has discretion to arrange alternatives (for example, arranging a Q&A session at a TOC meeting) to ensure there is ample opportunity to ask questions.
    * TOC Incubation Sponsor can ask project maintainers to complete the DD template. (In practice project maintainers sometimes choose to make a start on this in advance of the official DD process, or even in advance of the initial proposal as it may help them ensure they meet all the requirements.) The TOC Incubation Sponsor should carefully review and ask questions about the DD as prepared by the project maintainers, and may also call on TAGs to help with this. 
    * CNCF staff do governance and legal DD.
    * During DD some conversations may be held in private (e.g. user interviews where the user wishes to remain anonymous) and are documented using discretion.
-   * TOC Incubation Sponsor confirms that project meets the [https://github.com/cncf/toc/blob/main/process/graduation_criteria.md#incubation-stage](Incubation requirements).
+   * TOC Incubation Sponsor confirms that project meets the [Incubation requirements](https://github.com/cncf/toc/blob/main/process/graduation_criteria.md#incubation-stage).
    * TOC Incubation Sponsor determines when DD is “done”. DD documentation should then be on GitHub, open to public comment on record.
 . *Due Diligence review* _2-6 weeks_
    * TOC Incubation Sponsor announces on the TOC mailing list when the DD documents are available for public review and comment, which can take place on GitHub, the TOC mailing list, or at TOC public meetings. 
    * TOC Incubation sponsor decides when to call TOC vote, allowing at least two weeks for public comment before calling vote
 . *TOC vote* _up to 6 weeks_
-   * TOC members assess whether project meets the [https://github.com/cncf/toc/blob/main/process/graduation_criteria.md#incubating-stage](Incubation criteria)
+   * TOC members assess whether project meets the [Incubation criteria](https://github.com/cncf/toc/blob/main/process/graduation_criteria.md#incubating-stage)
    * Projects get accepted to incubation via a 2/3 supermajority vote of the TOC.
    * If the vote is not conclusive after 6 weeks, TOC chair may extend vote, or conclude that silence = abstain
 
 === Graduation process
 
 . *Submit Graduation Proposal Template*
-   * Project fills out and submits the [graduation-proposal-template.md](graduation proposal template)] in a pull request in the [https://github.com/cncf/toc](cncf/toc GitHub repo).
-   * The file containing the proposal should be located in [https://github.com/cncf/toc/tree/main/proposals/graduation](the graduation proposals directory).
+   * Project fills out and submits the [graduation proposal template](graduation-proposal-template.md) in a pull request in the [cncf/toc GitHub repo](https://github.com/cncf/toc).
+   * The file containing the proposal should be located in [the graduation proposals directory](https://github.com/cncf/toc/tree/main/proposals/graduation).
    * The proposal addresses how the project has grown since incubation and any concerns from incubation DD in addition to the standard graduation requirements.
    * Projects will be reviewed on a rolling basis as they apply, instead of two meetings a year.    
 . * If a TOC member steps forward to support the project as a sponsor and determines the Graduation DD document is finalized, the TOC member kicks off two week period of time for public comment on the TOC mailing list
@@ -84,7 +84,7 @@ All exceptions (and "no" outcomes) are handled by the TOC.
 * If the Graduation DD document is not finalized, the TOC sponsor will begin the process to refresh the existing DD document and begin the public comment process.
 
 . *TOC vote*
-   * TOC members assess whether project meets the [https://github.com/cncf/toc/blob/main/process/graduation_criteria.md#graduation-stage](Graduation criteria)
+   * TOC members assess whether project meets the [Graduation criteria](https://github.com/cncf/toc/blob/main/process/graduation_criteria.md#graduation-stage)
    * Projects must have a 2/3 supermajority vote of the TOC to graduate
 
 === Notes


### PR DESCRIPTION
I noticed that the the markdown links in `process/graduation_criteria.md` and `process/project_proposals.md` were filled out the wrong way around - it should be `[text](link)`. this PR fixes it.