### PR TITLE
Updating TOC 

### DIFF
--- a/EMERITUS.md
+++ b/EMERITUS.md
@@ -22,5 +22,6 @@ We would like to acknowledge previous TOC members and their huge contributions t
 * Saad Ali (2/4/2020-2/4/2022)
 * Sheng Liang (2/4/2020-2/4/2022)
 * Alena Prokharchyk (3/18/2020-3/18/2022)
+* Cornelia Davis (2/1/2021-5/9/2022)
 
 We thank these members for their service to the CNCF community.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The CNCF TOC is the technical governing body of the CNCF Foundation. It admits a
 
 * **Erin Boyd** (term: 2 years - start date: 2/1/2021 - 2/1/2023) [GB-appointed]
 * **Dave Zolotusky** (term: 2 years - start date: 2/1/2021 - 2/1/2023) [EndUser-appointed]
-* **Cornelia Davis** (term: 2 years - start date: 2/1/2021 - 2/1/2023) [GB-appointed]
+* **TBD** (term: remainder of 2 years - start date: 7/1/2022 - 2/1/2023) [GB-appointed]
 * **Lei Zhang** (term: 2 years - start date: 2/1/2021 - 2/1/2023) [GB-appointed]
 * **Davanum Srinivas** (term: 2 years - start date: 3/18/2021 - 3/18/2023) [TOC-appointed][TOC Chair]
 * **Justin Cormack** (term: 2 years - start date 2/4/2022 - 2/4/2024) [Maintainer-appointed]


### PR DESCRIPTION
Cornelia Davis stepped down from the TOC, effective 5/9/2022
GB appointed seat in nomination through June 7 
Qualification period: June 7 - June 21
Vote opens: June 21
Vote closes: June 28
Term begins: July 1 