### PR TITLE
Update links from .adoc to .md

### DIFF
--- a/.github/ISSUE_TEMPLATE/annual-review-template.md
+++ b/.github/ISSUE_TEMPLATE/annual-review-template.md
@@ -15,4 +15,4 @@ Your annual review should answer the following questions:
 [] How has the project performed against its goals since the last review? (We won't penalize you if your goals changed for good reasons.)
 [] What are the current goals of the project? For example, are you working on major new features? Or are you concentrating on adoption or documentation?
 [] How can the CNCF help you achieve your upcoming goals?
-[] Do you think that your project meets the criteria for [incubation](https://github.com/cncf/toc/blob/main/process/graduation_criteria.adoc#incubating-stage)?
+[] Do you think that your project meets the criteria for [incubation](https://github.com/cncf/toc/blob/main/process/graduation_criteria.md#incubating-stage)?

--- a/.github/ISSUE_TEMPLATE/project-onboarding.md
+++ b/.github/ISSUE_TEMPLATE/project-onboarding.md
@@ -12,7 +12,7 @@ We would like to complete onboarding within one month of acceptance.
 
 From the project side, please ensure that you:
 
-- [ ] Understand the project proposal process and reqs: <https://github.com/cncf/toc/blob/main/process/project_proposals.adoc#introduction>
+- [ ] Understand the project proposal process and reqs: <https://github.com/cncf/toc/blob/main/process/project_proposals.md#introduction>
 - [ ] Understand the services available for your project at CNCF <https://www.cncf.io/services-for-projects/>
 - [ ] Ensure your project meets the CNCF IP Policy: <https://github.com/cncf/foundation/blob/master/charter.md#11-ip-policy>
 - [ ] Review the online programs guidelines: <https://github.com/cncf/foundation/blob/master/online-programs-guidelines.md>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 
 If you're interested in contributing a project to CNCF, please open up an issue here for discussion: https://github.com/cncf/toc/issues
 
-The full project proposal process is located [here](https://github.com/cncf/toc/blob/main/process/project_proposals.adoc).
+The full project proposal process is located [here](https://github.com/cncf/toc/blob/main/process/project_proposals.md).
 
 ## TOC Contributors
 

--- a/FAQ.md
+++ b/FAQ.md
@@ -23,7 +23,7 @@ https://github.com/cncf/toc/tree/main/tags
 
 CNCF does not require its hosted projects to follow any specific governance model by default.
 
-Instead, CNCF [specifies](https://github.com/cncf/toc/blob/main/process/graduation_criteria.adoc) that graduated projects need to "[e]xplicitly define a project governance and committer process." 
+Instead, CNCF [specifies](https://github.com/cncf/toc/blob/main/process/graduation_criteria.md) that graduated projects need to "[e]xplicitly define a project governance and committer process." 
 
 This varied and [open governance](https://github.com/opengovernance/opengovernance.dev) approach has led to different projects defining what is best and optimized for their community: 
 
@@ -43,7 +43,7 @@ Neither the CNCF Governing Board (GB) nor the Technical Oversight Committee (TOC
 
 Instead, the maintainers of those projects manage them; this includes defining the governance process. The GB is responsible for the budget.
 
-TOC members are available to provide guidance and conflict resolution if desired to the projects but do not control them. The TOC also helps mature projects through the various CNCF project maturity levels to ensure projects meet the expected [graduation criteria](https://github.com/cncf/toc/blob/main/process/graduation_criteria.adoc). To date, we have had no meaningful disagreements between the TOC and project maintainers.
+TOC members are available to provide guidance and conflict resolution if desired to the projects but do not control them. The TOC also helps mature projects through the various CNCF project maturity levels to ensure projects meet the expected [graduation criteria](https://github.com/cncf/toc/blob/main/process/graduation_criteria.md). To date, we have had no meaningful disagreements between the TOC and project maintainers.
 
 Please see the [TOC Principles](https://github.com/cncf/toc/blob/main/PRINCIPLES.md) for more details.
 

--- a/PRINCIPLES.md
+++ b/PRINCIPLES.md
@@ -38,7 +38,7 @@ In the GitHub era, open projects are able to get a lot “done” without outsid
 - But: we do not want to impose bureaucracy on projects because that will slow them down.
 - Minimal viable governance also means that the TOC does not step in at a tactical level to overrule project leads’ decisions.
 - There are some basics like [Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md) - see Draft Statement below. Including dealing with problematic leads & maintainers.
-- There is a formal & regulated system of [Graduation Criteria](https://github.com/cncf/toc/blob/main/process/graduation_criteria.adoc) for CNCF Projects
+- There is a formal & regulated system of [Graduation Criteria](https://github.com/cncf/toc/blob/main/process/graduation_criteria.md) for CNCF Projects
 - The TOC/CNCF want the ability to intervene if things go really wrong - i.e., project leads are stuck and cannot fix things.
 - Provide a template for new projects, a set of best practices to help jump-start the task of setting up a new project.
 
@@ -55,7 +55,7 @@ _Principle: Great projects already have many ingredients to succeed. First: do n
 Identify projects that have a real shot at being a useful tool in the evolving box of cloud native technology. This is a mix of mature and early-stage projects.   Early stage may not have all the criteria we want: diverse contributor bases, formalized governance, interoperability, cloud-native designs, quality bar, etc. 
 
 Some considerations:
-- Transparent, consistent technical and governance quality bar for [graduation](/process/graduation_criteria.adoc) from incubation
+- Transparent, consistent technical and governance quality bar for [graduation](/process/graduation_criteria.md) from incubation
 - Has users, preferably in production; is a high quality, high-velocity project (for incubation and graduated projects). Inception level projects are targeted at earlier-stage projects to cultivate a community/technology
 - Has a committed and excited team that appears to understand the challenges ahead and wishes to meet them
 - Has a fundamentally sound design without obvious critical compromises that will inhibit potential widespread adoption

--- a/process/archiving.md
+++ b/process/archiving.md
@@ -27,4 +27,4 @@ What does archiving for a CNCF project mean?
 
 ## Reactivating an Archived Project
 
-Any project can be reactivated into CNCF by following the normal project [proposal](https://github.com/cncf/toc/blob/main/process/project_proposals.adoc) and/or [sandbox](https://github.com/cncf/toc/blob/main/process/sandbox.md) process.
+Any project can be reactivated into CNCF by following the normal project [proposal](https://github.com/cncf/toc/blob/main/process/project_proposals.md) and/or [sandbox](https://github.com/cncf/toc/blob/main/process/sandbox.md) process.

--- a/process/due-diligence-guidelines.md
+++ b/process/due-diligence-guidelines.md
@@ -19,7 +19,7 @@ inclusion of each project at the relevant time.
 To enable the voting TOC members to cast an informed vote about a
 project, it is crucial that each member is able to form their own
 opinion as to whether and to what extent the project meets the agreed
-upon [criteria](https://github.com/cncf/toc/blob/main/process/graduation_criteria.adoc) for
+upon [criteria](https://github.com/cncf/toc/blob/main/process/graduation_criteria.md) for
 sandbox, incubation, or graduation. As the leader of a DD, your job
 is to make sure that they have whatever information they need,
 succinctly and readily available, to form that opinion.
@@ -35,7 +35,7 @@ validity are ideally resolved, helps to foster this consensus.
 
 * Make sure you are clear on the [TOC Principles](https://github.com/cncf/toc/blob/main/PRINCIPLES.md),
   the [project proposal process](https://github.com/cncf/toc/blob/main/process/project_proposals.md),
-  the [graduation criteria](https://github.com/cncf/toc/blob/main/process/graduation_criteria.adoc),
+  the [graduation criteria](https://github.com/cncf/toc/blob/main/process/graduation_criteria.md),
   and the [desired cloud native properties](https://www.cncf.io/about/charter/).  The project sponsor (a member
   of the TOC) should have assisted in crafting the proposal to explain why it is a good fit for the CNCF. If anything is
   unclear to you, reach out to the project sponsor or, failing that, the TOC mailing list for advice.
@@ -44,12 +44,12 @@ validity are ideally resolved, helps to foster this consensus.
   Consider holding off on commenting on the PR until you have completed the next three steps.
 * Take a look at some [previous submissions](https://github.com/cncf/toc/pulls?utf8=%E2%9C%93&q=is%3Apr)
   (both successful and unsuccessful) to help calibrate your expectations.
-* Verify that all of the basic [project proposal requirements](https://github.com/cncf/toc/blob/main/process/project_proposals.adoc) have been provided.
+* Verify that all of the basic [project proposal requirements](https://github.com/cncf/toc/blob/main/process/project_proposals.md) have been provided.
 * Do as much reading up as you need to (and consult with experts in the specific field) in order to familiarize yourself with the technology
   landscape in the immediate vicinity of the project (and do not only use the proposal and that project's documentation as a guide in this regard).
 * At this point, you should have a very clear technical idea of what exactly the project actually does and does not do, roughly how it compares with and differs from
   similar projects in its technology area, and/or a set of unanswered questions in those regards.
-* Go through the [graduation criteria](https://github.com/cncf/toc/blob/main/process/graduation_criteria.adoc) and for each item,
+* Go through the [graduation criteria](https://github.com/cncf/toc/blob/main/process/graduation_criteria.md) and for each item,
   decide for yourself whether or not you have enough information to make a strong, informed call on that item.
   * If so, write it down, with motivation.
   * If not, jot down what information you feel you are missing.
@@ -91,7 +91,7 @@ the detail where necessary.
 
 #### Project
 
-The key high-level questions that the voting TOC members will be looking to have answered are (from the [graduation criteria](https://github.com/cncf/toc/blob/main/process/graduation_criteria.adoc)):
+The key high-level questions that the voting TOC members will be looking to have answered are (from the [graduation criteria](https://github.com/cncf/toc/blob/main/process/graduation_criteria.md)):
 
 * Do we believe this is a growing, thriving project with committed contributors?
 * Is it aligned with CNCF's values and mission?

--- a/process/sandbox-annual-review.md
+++ b/process/sandbox-annual-review.md
@@ -37,7 +37,7 @@ Your annual review should answer the following questions:
 * How has the project performed against its goals since the last review? (We won't penalize you if your goals changed for good reasons.)
 * What are the current goals of the project? For example, are you working on major new features? Or are you concentrating on adoption or documentation? 
 * How can the CNCF help you achieve your upcoming goals? 
-* Do you think that your project meets the [criteria for incubation](https://github.com/cncf/toc/blob/main/process/graduation_criteria.adoc#incubating-stage)? 
+* Do you think that your project meets the [criteria for incubation](https://github.com/cncf/toc/blob/main/process/graduation_criteria.md#incubating-stage)? 
 
 
 

--- a/proposals/graduation/graduation-tikv.md
+++ b/proposals/graduation/graduation-tikv.md
@@ -11,7 +11,7 @@ To highlight some of the achievements:
 - Adoptors: 1000+ (including commercial users and community users)
 - 4.0 GA released in May, 2020
 
-On behalf of the maintainers team, we believe TiKV is ready for [graduation stage](https://github.com/cncf/toc/blob/master/process/graduation_criteria.adoc#graduation-stage).
+On behalf of the maintainers team, we believe TiKV is ready for [graduation stage](https://github.com/cncf/toc/blob/master/process/graduation_criteria.md#graduation-stage).
 
 ## Graduation State Criteria
 

--- a/proposals/graduation/harbor.md
+++ b/proposals/graduation/harbor.md
@@ -2,7 +2,7 @@
 
 Since joining the CNCF in [July 2018](https://www.cncf.io/blog/2018/07/31/cncf-to-host-harbor-in-the-sandbox/) as a Sandbox project and in [November 2018](https://www.cncf.io/blog/2018/11/13/harbor-into-incubator/) moving to an Incubating Project, Harbor has built a healthy ecosystem of users, maintainers, and production implementations.
 
-On behalf of the maintainers team, we believe Harbor is ready for the CNCF [Graduation stage](https://github.com/cncf/toc/blob/master/process/graduation_criteria.adoc#graduation-stage) and meets the v1.2 criteria. We address the [CNCF Technical Due Diligence questions](tbd) in a separate Google Docs document (referred to as the `Tech-DD` from now on).
+On behalf of the maintainers team, we believe Harbor is ready for the CNCF [Graduation stage](https://github.com/cncf/toc/blob/master/process/graduation_criteria.md#graduation-stage) and meets the v1.2 criteria. We address the [CNCF Technical Due Diligence questions](tbd) in a separate Google Docs document (referred to as the `Tech-DD` from now on).
 
 *Name of project:* Harbor
 

--- a/proposals/graduation/helm.md
+++ b/proposals/graduation/helm.md
@@ -2,7 +2,7 @@
 
 Helm originally joined the CNCF when Kubernetes became the first CNCF project. Helm was a sub-project of Kubernetes at that time. Since joining the CNCF as an incubating sister project to Kubernetes in June 2018, Helm has released v3, created a governance appropriate for Helm, and has continued to watch the use of Helm grow and evolve.
 
-On behalf of the maintainers, we believe Helm is ready for [graduation stage](https://github.com/cncf/toc/blob/master/process/graduation_criteria.adoc#graduation-stage) and meets the v1.3 criteria. The Helm [due diligence questions](https://docs.google.com/document/d/1-5ncwLwikeQrAmeVAPuCYlWLYMCw2OmQuouTYCECYFk/edit), following the [guidelines](https://github.com/cncf/toc/blob/master/process/due-diligence-guidelines.md), can be found in a separate Google Docs document.
+On behalf of the maintainers, we believe Helm is ready for [graduation stage](https://github.com/cncf/toc/blob/master/process/graduation_criteria.md#graduation-stage) and meets the v1.3 criteria. The Helm [due diligence questions](https://docs.google.com/document/d/1-5ncwLwikeQrAmeVAPuCYlWLYMCw2OmQuouTYCECYFk/edit), following the [guidelines](https://github.com/cncf/toc/blob/master/process/due-diligence-guidelines.md), can be found in a separate Google Docs document.
 
 Helm has seen dramatic growth since joining incubation. For example,
 

--- a/proposals/pull_request_template.md
+++ b/proposals/pull_request_template.md
@@ -1,7 +1,7 @@
 Thank you for submitting your project proposal to CNCF!
 
 Before you submit your project, please ensure that:
-- [ ] Understand the project proposal process and reqs: https://github.com/cncf/toc/blob/master/process/project_proposals.adoc#introduction
+- [ ] Understand the project proposal process and reqs: https://github.com/cncf/toc/blob/master/process/project_proposals.md#introduction
 - [ ] Understand the services available for your project at CNCF https://www.cncf.io/services-for-projects/
 - [ ] Ensure your project meets the CNCF IP Policy: https://github.com/cncf/foundation/blob/master/charter.md#11-ip-policy
 - [ ] Has your project adopted open governing already? see http://opengovernance.dev

--- a/proposals/sandbox/LitmusChaos.md
+++ b/proposals/sandbox/LitmusChaos.md
@@ -1,6 +1,6 @@
 Hi, 
 
-We would like to propose to donate LitmusChaos to CNCF as a SandBox project. We have been advised to follow the new process outlined [here](https://github.com/cncf/toc/blob/master/process/project_proposals.adoc). The template we are following is outlined [here](https://github.com/cncf/toc/issues/344). 
+We would like to propose to donate LitmusChaos to CNCF as a SandBox project. We have been advised to follow the new process outlined [here](https://github.com/cncf/toc/blob/master/process/project_proposals.md). The template we are following is outlined [here](https://github.com/cncf/toc/issues/344). 
 
 Please consider this proposal and guide us through the process.
 

--- a/proposals/sandbox/k3s.md
+++ b/proposals/sandbox/k3s.md
@@ -94,7 +94,7 @@ This architecture is illustrated in the following diagram:
 
 
 ## Formal Requirements
-Here is k3s's status on [the formal requirements](https://github.com/cncf/toc/blob/master/process/graduation_criteria.adoc#sandbox-stage)
+Here is k3s's status on [the formal requirements](https://github.com/cncf/toc/blob/master/process/graduation_criteria.md#sandbox-stage)
 - Require 3 of the 11 TOC members to step forward as sponsors to enter the sandbox - Pending
 - Adopt the CNCF Code of Conduct - [k3s is adopting the CNCF Community Code of Conduct](https://github.com/rancher/k3s/pull/1783)
 - Adhere to CNCF IP Policy (including trademark transferred) - We agree to this policy and will work through the requirements with the CNCF as the process moves forward

--- a/proposals/sandbox/keylime.md
+++ b/proposals/sandbox/keylime.md
@@ -1,6 +1,6 @@
 For TOC Consideration: please adopt Keylime into CNCF as a SandBox project.
 This proposal is being made in accordance with the [**stated
-process**](https://github.com/cncf/toc/blob/master/process/project_proposals.adoc) and the
+process**](https://github.com/cncf/toc/blob/master/process/project_proposals.md) and the
 [**proposal template**](https://github.com/cncf/toc/issues/344).
 
 Authors: - Luke Hinds, @lukehinds, Red Hat, Keylime Project Lead

--- a/proposals/sandbox/kuma.md
+++ b/proposals/sandbox/kuma.md
@@ -1,6 +1,6 @@
 Hello,
 
-We would like to propose to donate Kuma to CNCF as a SandBox project. We are opening this GitHub issue according to the process outlined [here](https://github.com/cncf/toc/blob/master/process/project_proposals.adoc) with the format outlined [here](https://github.com/cncf/toc/issues/344).
+We would like to propose to donate Kuma to CNCF as a SandBox project. We are opening this GitHub issue according to the process outlined [here](https://github.com/cncf/toc/blob/master/process/project_proposals.md) with the format outlined [here](https://github.com/cncf/toc/issues/344).
 
 Authors:
 
@@ -148,7 +148,7 @@ More information can be accessed from the official documentation: https://kuma.i
 
 # Formal Requirements
 
-**_Document that the project fulfills the requirements as documented in the [CNCF graduation criteria for sandbox](https://github.com/cncf/toc/blob/master/process/graduation_criteria.adoc#sandbox-stage)_**
+**_Document that the project fulfills the requirements as documented in the [CNCF graduation criteria for sandbox](https://github.com/cncf/toc/blob/master/process/graduation_criteria.md#sandbox-stage)_**
 
 * We [have adopted](https://github.com/Kong/kuma/blob/master/CODE_OF_CONDUCT.md) the CNCF Code of Conduct.
 * Will adhere to the CNCF IP policy.

--- a/proposals/sandbox/parsec.md
+++ b/proposals/sandbox/parsec.md
@@ -1,6 +1,6 @@
 For TOC Consideration: please adopt PARSEC into CNCF as a SandBox project. This proposal is being
 made in accordance with the [**stated
-process**](https://github.com/cncf/toc/blob/master/process/project_proposals.adoc) and the
+process**](https://github.com/cncf/toc/blob/master/process/project_proposals.md) and the
 [**proposal template**](https://github.com/cncf/toc/issues/344).
 
 Authors: - Paul Howard, @paulhowardarm, Arm Limited, PARSEC technical lead

--- a/proposals/thanos-incubation.md
+++ b/proposals/thanos-incubation.md
@@ -1,7 +1,7 @@
 # Thanos Incubation Stage Proposal
  
 During Thanos presentation at the [CNCF TOC meeting on 7/9/2019](https://docs.google.com/presentation/d/1jhzJlSAAJNNil1nIYp60eSMH3LPd6AwqHLt3vEAzMSg/edit#slide=id.g5cdf155fc3_0_4)
-we were suggested by TOC members to apply straight for [the Incubation Stage](https://github.com/cncf/toc/blob/master/process/graduation_criteria.adoc#incubating-stage).
+we were suggested by TOC members to apply straight for [the Incubation Stage](https://github.com/cncf/toc/blob/master/process/graduation_criteria.md#incubating-stage).
 We all agreed back then that we will join Sandbox first and after that perform Due Diligence required for the Incubation Stage. 
  
 This proposal aims to address the Diligence requirements.

--- a/reviews/2020-KubeVirt-annual.md
+++ b/reviews/2020-KubeVirt-annual.md
@@ -124,7 +124,7 @@ These goals translate to multiple specific work items, including:
      office hours. We would like all these types of project support to continue.
 
  - Do you think that your project meets the [criteria for
-   incubation](https://github.com/cncf/toc/blob/master/process/graduation_criteria.adoc#incubating-stage)?
+   incubation](https://github.com/cncf/toc/blob/master/process/graduation_criteria.md#incubating-stage)?
  
    - We believe that the project is in a healthy growing status in both user
      adoption and contributors. We are working to properly document existing

--- a/reviews/2020-Network Service Mesh-annual.md
+++ b/reviews/2020-Network Service Mesh-annual.md
@@ -171,7 +171,7 @@ Network Service Mesh had [two releases](https://networkservicemesh.io/docs/relea
    enthusiastically, or we have been informed cannot be provided until we reach incubation or graduation as a matter of
    policy set by the Board and/or TOC.
 
-7. _Do you think that your project meets the [criteria for incubation](https://github.com/cncf/toc/blob/master/process/graduation_criteria.adoc#incubating-stage)?_
+7. _Do you think that your project meets the [criteria for incubation](https://github.com/cncf/toc/blob/master/process/graduation_criteria.md#incubating-stage)?_
 
    Network Service Mesh does not currently meet all criteria for incubation, but is on track to do so.
    

--- a/reviews/2020-kubeedge-annual.md
+++ b/reviews/2020-kubeedge-annual.md
@@ -143,7 +143,7 @@ KubeEdge falls in the scope of [CNCF Runtime SIG](https://github.com/cncf/sig-ru
   - We need more speaking and marketing opportunities to help attract more contributors and user adoptions.
   - We also need some technical writers to help improve documentation and website content.
 
-* Do you think that your project meets the [criteria for incubation](https://github.com/cncf/toc/blob/master/process/graduation_criteria.adoc#incubating-stage)?
+* Do you think that your project meets the [criteria for incubation](https://github.com/cncf/toc/blob/master/process/graduation_criteria.md#incubating-stage)?
   - Yes, incubation proposal is under preparation.
 
 ## Project Links

--- a/reviews/2020-openebs-annual.md
+++ b/reviews/2020-openebs-annual.md
@@ -161,7 +161,7 @@ Areas of future collaboration with the Rook community may include:
   - Embracing and communicating the use of Kubernetes in ways that may not have been originally anticipated or intended by the originators of Kubernetes, including as a substrate for a fundamentally new way of managing data and delivering storage capabilities.  For example, it may be useful to increasingly use a phrase such as Container Attached Storage to reflect this pattern.
   - Additional help with reviewing licenses used by sub components.  There may need to be a check if the licenses of these subcomponents - most notably CDDL - can be included in the CNCF whitelist policy or if these sub components should be held in another open source repository such as an OpenSource repository of MayaData or otherwise.
   
-- *Do you think that your project meets the [criteria for incubation](https://github.com/cncf/toc/blob/master/process/graduation_criteria.adoc#incubating-stage)?*
+- *Do you think that your project meets the [criteria for incubation](https://github.com/cncf/toc/blob/master/process/graduation_criteria.md#incubating-stage)?*
   
   Yes. We are in the process of completing the Due Diligence document and submitting the incubation proposal. 
 

--- a/reviews/2021-KEDA-annual.md
+++ b/reviews/2021-KEDA-annual.md
@@ -115,6 +115,6 @@ This is a tremendous help for us and supports us in making autoscaling simpler.
 
 ### Incubation
 
-> Do you think that your project meets the [criteria for incubation](https://github.com/cncf/toc/blob/master/process/graduation_criteria.adoc#incubating-stage)?
+> Do you think that your project meets the [criteria for incubation](https://github.com/cncf/toc/blob/master/process/graduation_criteria.md#incubating-stage)?
 
 Yes, we do, and we are planning to propose to graduate later this month/next month and is being tracked on [GitHub](https://github.com/kedacore/governance/issues/2).

--- a/reviews/2021-Kyverno-annual.md
+++ b/reviews/2021-Kyverno-annual.md
@@ -125,7 +125,7 @@ Some areas where we can use help are:
 
 ## Incubation
 
-> Do you think that your project meets the [criteria for incubation](https://github.com/cncf/toc/blob/master/process/graduation_criteria.adoc#incubating-stage)?
+> Do you think that your project meets the [criteria for incubation](https://github.com/cncf/toc/blob/master/process/graduation_criteria.md#incubating-stage)?
 
 Yes. The Kyverno project team has started planning a proposal for incubation and plans to submit it in the next month. This work is tracked in [issue #2838](https://github.com/kyverno/kyverno/issues/2838).
 

--- a/reviews/2021-Parsec-annual.md
+++ b/reviews/2021-Parsec-annual.md
@@ -105,7 +105,7 @@ Parsec will continue to look towards the CNCF for guidance in preparing itself f
 
 ## Readiness for Incubation
 
-Parsec does not yet meet the [stated criteria](https://github.com/cncf/toc/blob/main/process/graduation_criteria.adoc#incubating-stage) for incubation for the following reasons:
+Parsec does not yet meet the [stated criteria](https://github.com/cncf/toc/blob/main/process/graduation_criteria.md#incubating-stage) for incubation for the following reasons:
 
 - There are not yet three independent adoptions that are in production.
 - Security assessment still pending.

--- a/reviews/2021-artifacthub-annual.md
+++ b/reviews/2021-artifacthub-annual.md
@@ -78,6 +78,6 @@ We think there are two important ways that CNCF can help us with the growth of t
 
 ## Incubation
 
-> Do you think that your project meets the [criteria for incubation](https://github.com/cncf/toc/blob/master/process/graduation_criteria.adoc#incubating-stage)?
+> Do you think that your project meets the [criteria for incubation](https://github.com/cncf/toc/blob/master/process/graduation_criteria.md#incubating-stage)?
 
 Yes, we believe that Artifact Hub is ready and we now have [an issue](https://github.com/artifacthub/hub/issues/1418) to track progress at proposing a move to incubation.

--- a/reviews/2021-crossplane-annual.md
+++ b/reviews/2021-crossplane-annual.md
@@ -357,7 +357,7 @@ the project with the following:
 ## Incubation
 
 > Do you think that your project meets the [criteria for
-> incubation](https://github.com/cncf/toc/blob/master/process/graduation_criteria.adoc#incubating-stage)?
+> incubation](https://github.com/cncf/toc/blob/master/process/graduation_criteria.md#incubating-stage)?
 
 Yes, we very much believe Crossplane meets the criteria for incubation and have published the
 proposal on March 22, 2021.  We have presented to the App-Delivery TAG, published a full and

--- a/reviews/2021-dex-annual.md
+++ b/reviews/2021-dex-annual.md
@@ -136,7 +136,7 @@ but we are open to other suggestions, even some coaching/tips about reaching out
 
 ## Incubation
 
-> Do you think that your project meets the [criteria for incubation](https://github.com/cncf/toc/blob/main/process/graduation_criteria.adoc#incubating-stage)?
+> Do you think that your project meets the [criteria for incubation](https://github.com/cncf/toc/blob/main/process/graduation_criteria.md#incubating-stage)?
 
 No, at this point we don't feel that the project meets the criteria.
 We would like to grow more in terms of maintainers and known users before considering to move to the next stage.

--- a/reviews/2021-k3s-annual.md
+++ b/reviews/2021-k3s-annual.md
@@ -198,7 +198,7 @@ We want to achieve the above roadmap while also maintaining cadence with upstrea
 
 The CNCF has been helpful thus far by contributing CI resources. As we worked towards incubation, we'll likely reach out with specific, tactical asks as we encounter them.
 
-### Do you think that your project meets the [criteria for incubation](https://github.com/cncf/toc/blob/master/process/graduation_criteria.adoc#incubating-stage)?
+### Do you think that your project meets the [criteria for incubation](https://github.com/cncf/toc/blob/master/process/graduation_criteria.md#incubating-stage)?
 
 At this time, we aren't ready to submit for incubation status. Our goal is to submit next year. We'll use this upcoming year to prep for that and improve the areas of the project that need it.
 

--- a/reviews/2021-keptn-annual.md
+++ b/reviews/2021-keptn-annual.md
@@ -183,7 +183,7 @@ For our releases, Keptn maintainers follow the [release checklist](https://githu
 - The CNCF ecosystem is another driver for Keptn. We are already engaging with multiple CNCF projects and will further drive collaboration with the help of the CNCF.
 
 
-### Do you think that your project meets the [criteria for incubation](https://github.com/cncf/toc/blob/master/process/graduation_criteria.adoc#incubating-stage)?
+### Do you think that your project meets the [criteria for incubation](https://github.com/cncf/toc/blob/master/process/graduation_criteria.md#incubating-stage)?
 
 - Yes, we've also filed our [incubation proposal](https://github.com/cncf/toc/pull/670).
 

--- a/reviews/2021-kuma-annual.md
+++ b/reviews/2021-kuma-annual.md
@@ -116,7 +116,7 @@ What we've shipped since:
   - We would like to reintroduce a way to follow feature usage and installation count as it's hard to track adoption without this.
   - We could use with some help with some technical writing.
 
-### Do you think that your project meets the [criteria for incubation](https://github.com/cncf/toc/blob/master/process/graduation_criteria.adoc#incubating-stage)?
+### Do you think that your project meets the [criteria for incubation](https://github.com/cncf/toc/blob/master/process/graduation_criteria.md#incubating-stage)?
 
 No for the following reasons:
 

--- a/reviews/2021-litmuschaos-annual.md
+++ b/reviews/2021-litmuschaos-annual.md
@@ -192,7 +192,7 @@ on the board.
 - As part of the project goals for the upcoming year, there is increased collaboration planned with other CNCF projects (in terms of providing a joint solution/integration as
 well as help them by enabling project(app)-specific experiments). A forum to ease these interactions or present findings jointly would be much beneficial. 
 
-### Do you think that your project meets the [criteria for incubation](https://github.com/cncf/toc/blob/master/process/graduation_criteria.adoc#incubating-stage)?
+### Do you think that your project meets the [criteria for incubation](https://github.com/cncf/toc/blob/master/process/graduation_criteria.md#incubating-stage)?
 
 Yes, we've also filed our [incubation proposal](https://github.com/cncf/toc/pull/569).
 

--- a/reviews/2021-openebs-annual.md
+++ b/reviews/2021-openebs-annual.md
@@ -109,7 +109,7 @@ We are looking forward to the continued support in the above areas and as well a
 
 ### Incubation
 
-**Do you think that your project meets the [criteria for incubation](https://github.com/cncf/toc/blob/master/process/graduation_criteria.adoc#incubating-stage)?**
+**Do you think that your project meets the [criteria for incubation](https://github.com/cncf/toc/blob/master/process/graduation_criteria.md#incubating-stage)?**
 
 Yes, we do, and we are planning to present the progress we have made since our last [CNCF Storage TAG review](https://github.com/cncf/toc/pull/506#issuecomment-756153457) and move towards the next steps.
 

--- a/reviews/2021-volcano-annual.md
+++ b/reviews/2021-volcano-annual.md
@@ -145,7 +145,7 @@ Volcano falls in the scope of [CNCF Runtime SIG](https://github.com/cncf/sig-run
   - We need more speaking and marketing opportunities to help attract more contributors and user adoptions.
   - We also need some technical writers to help improve documentation and website content.
 
-* Do you think that your project meets the [criteria for incubation](https://github.com/cncf/toc/blob/master/process/graduation_criteria.adoc#incubating-stage)?
+* Do you think that your project meets the [criteria for incubation](https://github.com/cncf/toc/blob/master/process/graduation_criteria.md#incubating-stage)?
   - Yes, incubation proposal is under preparation.
 
 ## Project Links

--- a/reviews/2022-Network Service Mesh-annual.md
+++ b/reviews/2022-Network Service Mesh-annual.md
@@ -152,7 +152,7 @@ Network Service Mesh had three release in the last year:
    enthusiastically, or we have been informed cannot be provided until we reach incubation or graduation as a matter of
    policy set by the Board and/or TOC.
 
-7. _Do you think that your project meets the [criteria for incubation](https://github.com/cncf/toc/blob/master/process/graduation_criteria.adoc#incubating-stage)?_
+7. _Do you think that your project meets the [criteria for incubation](https://github.com/cncf/toc/blob/master/process/graduation_criteria.md#incubating-stage)?_
 
    Network Service Mesh does not currently meet all criteria for incubation, but is on track to do so.
    

--- a/reviews/2022-SchemaHero-annual.md
+++ b/reviews/2022-SchemaHero-annual.md
@@ -114,7 +114,7 @@ Some areas where we'd like to get continued and additional help are:
 
 ## Incubation
 
-> Do you think that your project meets the [criteria for incubation](https://github.com/cncf/toc/blob/master/process/graduation_criteria.adoc#incubating-stage)?
+> Do you think that your project meets the [criteria for incubation](https://github.com/cncf/toc/blob/master/process/graduation_criteria.md#incubating-stage)?
 
 Not at this time. It's the goal of the Schemahero project to continue to build in the Sandbox for the next year to increase production-grade adoption and add additional maintaining organizations. Once the project has achieved production status and has moved out of evaluation phases at adopting organizations, we will start planning for incubation.
 

--- a/reviews/2022-cert-manager-annual.md
+++ b/reviews/2022-cert-manager-annual.md
@@ -56,7 +56,7 @@ Importantly, we also received the donation of the [`aws-privateca-issuer`](https
 
 In the short term, a major goal is to complete the migration of the [jetstack/cert-manager](https://github.com/jetstack/cert-manager) repo into the [cert-manager organization](https://github.com/cert-manager/).
 
-After that, the guiding star will be to target CNCF [incubation](https://github.com/cncf/toc/blob/main/process/graduation_criteria.adoc#incubating-stage), since we believe cert-manager to be a strong candidate for incubation.
+After that, the guiding star will be to target CNCF [incubation](https://github.com/cncf/toc/blob/main/process/graduation_criteria.md#incubating-stage), since we believe cert-manager to be a strong candidate for incubation.
 
 We also aim to grow our support for new features and tools in the cloud native ecosystem; recent and ongoing examples include the [Kubernetes Gateway API](https://gateway-api.sigs.k8s.io/) and the Kubernetes [CertificateSigningRequest](https://kubernetes.io/docs/reference/access-authn-authz/certificate-signing-requests/) resource. We're always on the lookout for more in this space.
 
@@ -81,7 +81,7 @@ Put more generally, we ideally don't want to reinvent the wheel when it comes to
 
 ## Incubation
 
-Based on the [graduation criteria](https://github.com/cncf/toc/blob/main/process/graduation_criteria.adoc#incubating-stage), cert-manager seems to already tick the relevant boxes required for incubation. We believe cert-manager to be a strong candidate for incubation based on the following:
+Based on the [graduation criteria](https://github.com/cncf/toc/blob/main/process/graduation_criteria.md#incubating-stage), cert-manager seems to already tick the relevant boxes required for incubation. We believe cert-manager to be a strong candidate for incubation based on the following:
 
 - Document that it is being used successfully in production by at least three independent end users   
   cert-manager is used in production by _many_ more than three independent end users; it shouldn't be hard to find a few case studies if needed. Several major cloud native projects including [Istio](https://istio.io/latest/docs/ops/integrations/certmanager/), the [Kubernetes Cluster API](https://cluster-api.sigs.k8s.io/developer/guide.html#cert-manager) and [Knative](https://knative.dev/development/install/serving/installing-cert-manager/) suggest or require that cert-manager be installed.

--- a/reviews/graduation-containerd.md
+++ b/reviews/graduation-containerd.md
@@ -4,7 +4,7 @@ Since the [March 2017 announcement](https://www.cncf.io/announcement/2017/03/29/
 
 In late 2017, containerd announced its [1.0 release](https://blog.docker.com/2017/12/cncf-containerd-1-0-ga-announcement/), followed in early 2018 by a 1.1 release that has been updated with several minor fix releases through 2018. The containerd team has just completed the next major release, [1.2.0](https://github.com/containerd/containerd/releases/tag/v1.2.0), with more complete Windows runtime support and a new runtime shim v2 API that is [proving](https://www.cncf.io/blog/2018/09/17/gsoc-18-kata-containers-support-for-containerd/) [valuable](https://twitter.com/resouer/status/1035066629887905792) for [runc](https://github.com/opencontainers/runc) alternatives like [Kata containers](https://katacontainers.io/).
 
-At this time, we believe containerd is ready for the [graduation stage](https://github.com/cncf/toc/blob/master/process/graduation_criteria.adoc#graduation-stage) within the CNCF, and per the guidelines listed there, we detail our readiness in the section below.
+At this time, we believe containerd is ready for the [graduation stage](https://github.com/cncf/toc/blob/master/process/graduation_criteria.md#graduation-stage) within the CNCF, and per the guidelines listed there, we detail our readiness in the section below.
 
 ### CNCF Graduation Criteria
 

--- a/reviews/graduation-rook.md
+++ b/reviews/graduation-rook.md
@@ -7,7 +7,7 @@ time of acceptance) for details on the acceptance criteria at the time of those 
 In the time since being accepted to the incubation stage, Rook has demonstrated healthy growth of
 the community, continually released new features, and expanded storage provider support.  This
 proposal focuses on Rook's maturity and compliance with the [CNCF Graduation Criteria
-v1.3](https://github.com/cncf/toc/blob/master/process/graduation_criteria.adoc).
+v1.3](https://github.com/cncf/toc/blob/master/process/graduation_criteria.md).
 
 Every major project and community statistic has [**increased
 2-3x**](https://docs.google.com/presentation/d/1mMPYMDC4JMGWhoL3FzFgeasSLJepNwYMfwQD-T_gET4/edit#slide=id.g3e2163a66f_0_0)

--- a/reviews/graduation-vitess.md
+++ b/reviews/graduation-vitess.md
@@ -2,7 +2,7 @@
 
 Since joining the CNCF in [February 2018](https://www.cncf.io/blog/2018/02/05/cncf-host-vitess/) as an incubation project, Vitess has built a healthy ecosystem of maintainers and production adoptions.
 
-On behalf of the maintainers team, we believe Vitess is ready for [graduation stage](https://github.com/cncf/toc/blob/master/process/graduation_criteria.adoc#graduation-stage) and meets the v1.2 criteria. As the criteria has evolved since February 2018, we include also answers for incubation criteria and address [due dilligence questions](https://docs.google.com/document/d/1TDlRdgfTiEWunpav-G8gkaQF7Zk84-9tNAXyv1I0Kws/edit) in a separate Google Docs document.
+On behalf of the maintainers team, we believe Vitess is ready for [graduation stage](https://github.com/cncf/toc/blob/master/process/graduation_criteria.md#graduation-stage) and meets the v1.2 criteria. As the criteria has evolved since February 2018, we include also answers for incubation criteria and address [due dilligence questions](https://docs.google.com/document/d/1TDlRdgfTiEWunpav-G8gkaQF7Zk84-9tNAXyv1I0Kws/edit) in a separate Google Docs document.
 
 ### CNCF Incubation Criteria
 


### PR DESCRIPTION
Previously we had renamed some pages from .adoc to .md, which broke some links. I've updated the links for the proposal_process.adoc and graduation_criteria.adoc pages to use the new extension, .md. I have also done a sweep of the entire repository for those old links and updated previously submitted reviews and proposals so that their links work too.