### PR TITLE
docs: projects: fix link to CRI-O announcement

### DIFF
--- a/docs/projects.md
+++ b/docs/projects.md
@@ -209,7 +209,7 @@
 [Flux](https://github.com/fluxcd/flux2) | [11/10/2021](https://fluxcd.io/FluxFinalReport-v1.1.pdf) | [Announcement](http://fluxcd.io/blog/2021-11-10-flux-security-audit/) | CNCF | [ADA Logics](https://adalogics.com)
 [Argo](https://github.com/argoproj/argoproj) | [2/28/2022](https://github.com/argoproj/argoproj/blob/dd7cae43d81c5a11f21ff4ea0a4afadcae4799c7/docs/audit_fuzzer_adalogics_2022.pdf) | [Announcement](https://blog.argoproj.io/argo-security-automation-with-oss-fuzz-da38c1f86452) | CNCF | [ADA Logics](https://adalogics.com)
 [etcd](https://github.com/etcd-io/etcd) | [3/11/2022](https://github.com/etcd-io/etcd/blob/main/security/FUZZING_AUDIT_2022.PDF) | [Announcement](https://etcd.io/blog/2022/etcd-integrates-continuous-fuzzing/) | CNCF | [ADA Logics](https://adalogics.com)
-[crio](https://github.com/cri-o/cri-o/) | [6/6/2022](https://github.com/cri-o/cri-o/pull/5938) | [Announcement](https://etcd.io/blog/2022/etcd-integrates-continuous-fuzzing/) | CNCF | [ADA Logics](https://adalogics.com)
+[crio](https://github.com/cri-o/cri-o/) | [6/6/2022](https://github.com/cri-o/cri-o/pull/5938) | [Announcement](https://www.cncf.io/blog/2022/06/06/ada-logics-cri-o-holistic-security-audit-engagement/) | CNCF | [ADA Logics](https://adalogics.com)
 
 
 ## Archived Projects


### PR DESCRIPTION
The old link was set to the etcd announcement. We should use the CRI-O announcement.

@caniszczyk 

Signed-off-by: DavidKorczynski <david@adalogics.com>