### PR TITLE
Proposal: Archiving Brigade

### DIFF
--- a/docs/PROJECTS.csv
+++ b/docs/PROJECTS.csv
@@ -31,7 +31,7 @@
 30,etcd,Brian Grant,8/7/18,12/11/2018,2018,Graduation,No - DCO,No,Yes - needs review,No,Yes  - corporate addresses for reporting,IRC,Netlify
 31,TiKV,"Ben Hindman, Bryan Cantrill",7/3/18,8/28/2018,2018,Graduation,No - DCO ,Yes,No,No,Yes  -corporate email for reporting,tikv-wg.slack.com,Netlify
 32,KubeEdge,"Brendan Burns, Quinton Hoole",3/12/19,3/18/2019,2019,Incubation,No,No,No,No,Yes,https://kubeedge.slack.com/,Netlify
-33,Brigade,"Brendan Burns, Quinton Hoole",3/12/19,3/18/2019,2019,Sandbox,No - DCO,Yes,No,No,Yes,CNCF,Netlify
+33,Brigade,"Brendan Burns, Quinton Hoole",3/12/19,3/18/2019,2019,Archived,No - DCO,Yes,No,No,Yes,CNCF,Netlify
 34,Network Service Mesh,"Joe Beda, Matt Klein",4/9/19,4/11/2019,2019,Sandbox,No,No,No,No,No,CNCF,Netlify
 35,OpenTelemetry,"Brendan Burns, Brian Grant, Matt Klein",5/7/19,5/7/2019,2019,Incubation,Yes,Yes,No,No,Yes,https://gitter.im/open-telemetry/community,Netlify
 36,OpenEBS,"Alexis Richardson, Xiang Li",5/14/19,5/14/2019,2019,Sandbox,No - DCO ,Yes,No,No,Yes,CNCF + Kubernetes,Netlify

--- a/docs/projects.md
+++ b/docs/projects.md
@@ -32,7 +32,6 @@
 [Virtual Kubelet](https://github.com/virtual-kubelet/virtual-kubelet)|Alexis Richardson, Quinton Hoole|[9/18/18](https://github.com/cncf/toc/issues/154)|[12/4/18](https://github.com/virtual-kubelet/virtual-kubelet)|Sandbox
 [etcd](https://github.com/etcd-io/etcd)|Brian Grant|[8/7/18](https://github.com/cncf/toc/pull/143)|[12/11/18](https://www.cncf.io/blog/2018/12/11/cncf-to-host-etcd)|Graduated
 [KubeEdge](https://github.com/kubeedge/kubeedge)|Brendan Burns, Quinton Hoole|[3/12/19](https://github.com/cncf/toc/pull/205)|[3/18/19](https://github.com/kubeedge/kubeedge)|Incubating
-[Brigade](https://github.com/brigadecore)|Brendan Burns, Quinton Hoole|[3/12/19](https://github.com/cncf/toc/pull/203)|[3/18/19](https://github.com/brigadecore)|Sandbox
 [Network Service Mesh](https://github.com/networkservicemesh/)|Joe Beda, Matt Klein|[4/9/19](https://github.com/cncf/toc/pull/212)|[4/11/19](https://github.com/networkservicemesh/)|Sandbox
 [OpenTelemetry](https://github.com/open-telemetry/community)|Brendan Burns, Brian Grant, Matt Klein|[5/7/19](https://github.com/cncf/toc/pull/233)|[5/7/19](https://github.com/open-telemetry/community)|Incubating
 [OpenEBS](https://github.com/openebs/openebs)|Alexis Richardson, Xiang Li|[5/14/19](https://github.com/cncf/toc/pull/224)|[5/14/19](https://github.com/openebs/openebs)|Sandbox
@@ -233,4 +232,5 @@
 :-----:|:-----:|:-----:|:-----:|:-----:
 [rkt](http://rkt.io)|Brian Grant|[3/15/17](https://docs.google.com/presentation/d/1KzA58_Zz30mKKzeLuSvXLh63aIC75KRdAOTw4PJ_10g/edit?usp=sharing)|[8/16/19](https://www.cncf.io/blog/2019/08/16/cncf-archives-the-rkt-project/)|Archived
 [OpenTracing](http://opentracing.io/)|Bryan Cantrill|[8/17/16](https://docs.google.com/presentation/d/1kQkmJtT0bjSRvUTP5YFTKaXSfIM3aL7zxja_KtZtbgw/edit#slide=id.g15fc45ec1a_0_165)|[01/31/22](https://www.cncf.io/blog/2022/01/31/cncf-archives-the-opentracing-project/)|Archived
+[Brigade](https://github.com/brigadecore)|Brendan Burns, Quinton Hoole|[3/12/19](https://github.com/cncf/toc/pull/203)|[3/18/19](https://github.com/brigadecore)|Archived
 

--- a/proposals/archive/brigade.md
+++ b/proposals/archive/brigade.md
@@ -1,0 +1,7 @@
+# Brigade Archiving Review
+
+As discussed in [Health of Brigade project](https://github.com/cncf/toc/issues/900), Brigade has no active maintainers and no contributors ready to become maintainers. The consensus in this issue was that we should suggest the project for archival.
+
+In the [2022 Brigade Annual Review](https://github.com/cncf/toc/blob/main/reviews/2022-Brigade-annual.md), Brigade's core maintainers suggested that the project be archived, giving data to support this recommendation.
+
+As per the [CNCF Project Archiving Process](https://github.com/cncf/toc/blob/main/process/archiving.md), this archival proposal is now being PRed to the TOC repo.


### PR DESCRIPTION
As discussed in [Health of Brigade project](https://github.com/cncf/toc/issues/900), Brigade has no active maintainers and no contributors ready to become maintainers. The consensus in this issue was that we should suggest the project for archival.

In the [2022 Brigade Annual Review](https://github.com/cncf/toc/blob/main/reviews/2022-Brigade-annual.md), Brigade's core maintainers suggested that the project be archived, giving data to support this recommendation.

As per the [CNCF Project Archiving Process](https://github.com/cncf/toc/blob/main/process/archiving.md), this archival proposal is now being PRed to the TOC repo.



Signed-off-by: Bridget Kromhout <bridget@kromhout.org>