### PR TITLE
Update observability.md adding TAG co-chair

### DIFF
--- a/tags/observability.md
+++ b/tags/observability.md
@@ -191,9 +191,9 @@ Examples include:
 - [Roles][tagroles] for TAG Observability
   - TOC Liaison: Lei Zhang, Cathy Zhang
   - TAG Chairs:
+    - [Alolita Sharma] [alolita]
     - [Matthew Young][matthew young]
     - [Richard Hartmann][Richard Hartmann]
-    - TBD
   - Tech Leads ([definition][tagtldefinition], [TL election][tagtlprocess])
     - Bartłomiej Płotka
     - TBD more


### PR DESCRIPTION
Update observability.md to include TAG co-chair Alolita Sharma who has been serving as co-chair since Fall 2021.

Signed-off-by: Alolita Sharma <1942529+alolita@users.noreply.github.com>