### PR TITLE
Clarify graduation submission requirements/review

### DIFF
--- a/process/graduation-proposal-template.md
+++ b/process/graduation-proposal-template.md
@@ -1,25 +1,199 @@
 # [Project] Graduation Proposal
 
-_**Insert introduction. See previous proposals for examples. This section should address from a broad perspective why the project feels they are ready to graduation and can state any major accomplishments or milestones.**_
+## Instructions:
+* replace all `???`s with the requested information.
+* elaborate on any prompt to explain the information provided.  Especially if
+  the data provided might seem inconsistent when compared to other projects.
+* for any prompt that requires a private answer put `available upon request`.
+* in most cases, the URLs provided should be to resources within the project's
+  GitHub repo or website rather than personal or private resources.
 
-## Graduation State Criteria
-_**Project should address each graduation criteria listed below**_
+## Project Summary
 
-### * Have committers from at least two organizations.
+1. Name of project: ???
+1. URL to project website:
+   * ???
+1. URL to GitHub repo:
+   * ???
+1. Project description (e.g. what it does, its value, origin, history):
+   * ???
+1. URL to list of project adopters (e.g. ADOPTERS.md or logos on the project 
+   website. For a spec have a list of adopters for the implementation(s) of the
+   spec):
+   * ???
+1. License type (should be Apache 2): ???
+1. URL to license:
+   * ???
+1. TOC sponsor name (if one exists): ???
+1. URL to Core Infrastructure Initiative
+   [Best Practices Badge](https://bestpractices.coreinfrastructure.org/):
+   * ???
+1. URLs to required reviews:
+   * Independent and 3rd party security audit results:
+     * ???
+1. URLs to governance documentation:
+   * ???
+1. Active maintainers:
+   * URL to document listing current active maintainers:
+     * ???
+   * Organizations with active maintainers as of the time of this PR (should
+     have at least 2 orgs):
+     * ???org (???#ofMaintainersFromOrg)
+1. URLs to previous CNCF applications (e.g. sandbox, incubator):
+   * sandbox: ???
+   * incubator: ???
 
-### * Have achieved and maintained a [Core Infrastructure Initiative Best Practices Badge](https://bestpractices.coreinfrastructure.org/).
 
-### * Have completed an independent and third party security audit with results published of similar scope and quality as [this example](https://github.com/envoyproxy/envoy#security-audit) which includes all critical vulnerabilities and all critical vulnerabilities need to be addressed before graduation.
+## Graduation Information
 
-### * Explicitly define a project governance and committer process. The committer process should cover the full committer lifecycle including onboarding and offboarding or emeritus criteria. This preferably is laid out in a GOVERNANCE.md file and references an OWNERS.md file showing the current and emeritus committers.
+1. Why is this project ready to graduate?
+   * ???
 
-### * Explicitly define the criteria, process and offboarding or emeritus conditions for project maintainers; or those who may interact with the CNCF on behalf of the project. The list of maintainers should be preferably be stored in a MAINTAINERS.md file and audited at a minimum of an annual cadence.
+1. What has changed since the project was approved for incubation?
+   * ???
 
-### * Have a public list of Project adopters for at least the primary repo (e.g., ADOPTERS.md or logos on the Project website). For a specification, have a list of adopters for the implementation(s) of the spec. Refer to [FAQs](https://github.com/cncf/toc/blob/main/FAQ.md#what-is-the-definition-of-an-adopter) for guidelines on identifying adopters.
+1. How can the project survive its founders and founding companies?
+   * ???
 
-## Incubation Details
-_**Project should address each area listed below**_
+1. Project adopters:
+   * Typical adopters (e.g. cloud providers, end users):
+     * ???
+   * Provide a list of adopters who are willing to chat with the TOC about
+     their experiences with the project and its community (about 2-4. Questions
+     might include: how/why do you use it? its stengths and weaknesses? 
+     are community interactions positive/responsive/timely?):
+     * ???name (???id at ???domainName)
+   * Adopter quotes with attribution:
+     * ???name : ???quote
 
-### * Link to Incubation Due Diligence(DD) Document
 
-### * Address any concerns or recommendations from the TAG and/or TOC sponsor(s) from the DD Document
+## Due Diligence
+
+### Project Details
+
+1. What is the origin and history of the project?
+   * ???
+
+1. Describe how the project is useful to the cloud native community and how it
+   complements other cloud native (CNCF) projects:
+   * ???
+
+1. Scope of the project:
+   * primary in-scope use cases supported today:
+     * ???
+   * planned use cases (in the roadmap):
+     * ???
+   * out-of-scope use cases:
+     * ???
+
+### Governance and Processes
+
+1. Link to the project's Code of Conduct that adheres to the CNCF guidelines:
+   * ???
+
+1. Describe the governance (decision making) process of the project (a link to
+   the governance doc was provided above, so this is an opportunity to explain
+   (in plain English) how the project is self-governed and community driven):
+   * ???
+
+1. Describe how the project is aligned with the
+   [CNCF principles](https://github.com/cncf/toc/blob/main/PRINCIPLES.md):
+   * ???
+
+1. URLs to maintainer and emeritus processes (The processes should cover the
+   full maintainer lifecycle including onboarding, offboarding and emeritus
+   criteria. This preferably is laid out in a GOVERNANCE.md file and references
+   an OWNERS.md file showing the current and emeritus maintainers):
+   * ???
+
+1. Change and issue processes:
+   * URL to issues:
+     * ???
+   * URL to PRs/change requests:
+     * ???
+   * Does the project use a CLA, DCO or something else?
+     * ???
+   * How are security issues reported?
+     * ???
+
+1. Is there any external funding for the project beyond what the CNF provides?
+   * ???
+
+### Health and Adoption
+
+1. Provide evidence of production deployments that are of high-quality and
+   high velocity (e.g. list of independent adopters who are using it in
+   production):
+   * ???
+
+1. URLs to commit stats of the project (something that shows the rate of change
+   in the project, and by which organization, over time, issue/PR velocity
+   tracking stats):
+   * ???
+
+1. Information about the project's community size and/or sponsorships
+   (details to help the TOC guage the popularity and adoption rate of the
+   project within the cloud native community):
+   ???
+
+1. Compare and contrast with peers in this space (e.g. textual, summary matrix,
+   strengths/weaknesses, when would a peer be a better fit for an adopter):
+   * ???
+
+### Community
+
+1. Describe the communication mechanisms used within the project team members
+   and with the broader community (e.g. email, slack, blogs):
+   * ???
+
+1. What is the time commitment to the project? (e.g. how many are full-time vs
+   part-time? hours per week for maintainers):
+   * ???
+
+1. How are roles within the project defined and assigned? (e.g. release lead,
+   architect, wg lead):
+   * ???
+
+### Development and Technical Details
+
+1. URL to the release methodology and mechanics (versioning model - e.g.
+   semver):
+   * ???
+
+1. URLs to architectural high-level designs and feature overviews of the
+   project:
+   * ???
+
+1. Provide any information related to the performance, scalability and resource
+   consumption of the project (e.g. URLs to testing results. Trade-offs made
+   regarding, performance, scalability, complexity, reliability, security, etc.
+   Are they implicit or explicit? Why? Are they user-tunable?):
+   * ???
+
+1. Provide any information about known gaps (e.g. no HA, no flow control,
+   integration issues):
+   * ???
+
+1. URLs on how code reviews are done:
+   * ???
+
+1. Provide information about the CI/CD process and status (how do you test?
+   measure code coverage? test for vulnerabilities? Types of testing: unit,
+   integration, interface, end-to-end):
+   * ???
+
+1. List any external dependencies (including licenses):
+   * ???
+
+1. Are there any licensing issues to be aware of?
+   * ???
+
+1. What are the recommended operational models? E.g. how is it operated in a
+   cloud native environment, such as Kubernetes:
+   * ???
+
+1. Provide links and information about the project's documentation? Is it
+   translated into non-English languages?
+   * ???
+
+

--- a/process/graduation-proposal-template.md
+++ b/process/graduation-proposal-template.md
@@ -17,7 +17,7 @@
    * ???
 1. Project description (e.g. what it does, its value, origin, history):
    * ???
-1. URL to list of project adopters (e.g. ADOPTERS.md or logos on the project 
+1. URL to list of project adopters (e.g. ADOPTERS.md or logos on the project
    website. For a spec have a list of adopters for the implementation(s) of the
    spec):
    * ???
@@ -60,7 +60,7 @@
      * ???
    * Provide a list of adopters who are willing to chat with the TOC about
      their experiences with the project and its community (about 2-4. Questions
-     might include: how/why do you use it? its stengths and weaknesses? 
+     might include: how/why do you use it? its stengths and weaknesses?
      are community interactions positive/responsive/timely?):
      * ???name (???id at ???domainName)
    * Adopter quotes with attribution:
@@ -96,15 +96,25 @@
    (in plain English) how the project is self-governed and community driven):
    * ???
 
+1. If there are any votes taken (outside of PR reviews), please describe why
+   they occur and provide URLs that document the processes:
+   * ???
+
 1. Describe how the project is aligned with the
    [CNCF principles](https://github.com/cncf/toc/blob/main/PRINCIPLES.md):
    * ???
 
-1. URLs to maintainer and emeritus processes (The processes should cover the
-   full maintainer lifecycle including onboarding, offboarding and emeritus
-   criteria. This preferably is laid out in a GOVERNANCE.md file and references
-   an OWNERS.md file showing the current and emeritus maintainers):
-   * ???
+1. Maintainer and emeritus process:
+   * URLs to the processes (the processes should cover the full maintainer
+     lifecycle including onboarding, offboarding and emeritus criteria. This
+     preferably is laid out in a GOVERNANCE.md file and references an OWNERS.md
+     file showing the current and emeritus maintainers):
+     * ???
+   * Summary of maintainer eligibility requirements (can copy from
+     GOVERNANCE.md):
+     * ???
+   * Summary of criteria for maintainer removal (can copy from GOVENANCE.md):
+     * ???
 
 1. Change and issue processes:
    * URL to issues:
@@ -158,6 +168,9 @@
 
 1. URL to the release methodology and mechanics (versioning model - e.g.
    semver):
+   * ???
+
+1. URL to feature deprecation process:
    * ???
 
 1. URLs to architectural high-level designs and feature overviews of the

--- a/proposals/graduation/README.md
+++ b/proposals/graduation/README.md
@@ -1,3 +1,16 @@
 # Graduation Proposals
 
-Projects looking to graduate from the incubation stage can add their proposals to this directory.
+Projects looking to graduate from the incubation stage can submit a
+[Pull Request](https://github.com/cncf/toc/pulls) that includes a new file
+`proposals/graduation/NAME.md` (where `NAME` is the name of the project such
+that spaces are replace with dashes (`-`)) based on the
+[graduation template file](../../process/graduation-proposal-template.md).
+
+Once the PR is submitted the following process will be followed:
+- TOC, TAG or other members of the CNCF may comment on the PR to ask for
+  additional information or clarifications.
+- Once all open comments have been addressed and at least 6 TOC members
+  have `LTGM` (approved) the PR (and no one has `NOT LGTM`d the PR), 
+  the author of the PR should ping `@amye` to ask for the PR to be
+  scheduled for review during an upcoming TOC call.
+


### PR DESCRIPTION
As I look at the graduation process for CloudEvents and KEDA it appears that the current process might need a bit of tweaking to help speed things up. Some observations/suggestions, from an outsider's point of view:
- not everything that is required of a project is documented. While there are some (what I would call) house-keeping requirements (like a COC, best practices badges), it's not clear what about the project and its community make it worthy of being "graduated". The graduation template does ask "why do you think you're ready?", but there's little in the way of guidance to indicate what the minimum bars are to to be approved. As a result, my impression is that it feels more like a "gut feel" of the TOC more than anything else. Granted, in the end that might be what it needs to be since having hard metrics to cover both "explosive growth projects" as well as "mature, slow moving but valued projects" might not be possible. However, we should document those cases where firm requirements are known (e.g. at least 2 orgs have maintainers), and then simply ask for the stats for the other metrics of interest. Either way, any data that the TOC uses should be documented as part of the graduation application. Very related to the discussion in https://github.com/cncf/toc/issues/992 .
- the TOC members are busy and therefore are the bottleneck when it comes to preparing the data that is to be reviewed. I'm proposing that we shift that burden to the project itself. To go along with the previous bullet, the graduation application should include all information the TOC members would like to review - then it's up to the project to provide that information. This shift the burden of the TOC (or the single TOC sponsor) from information gathers to application/information reviewer. If more information is needed then the TOC (or any other CNCF memebr) can ask for it via comments on the application PR.

To that end, this PR proposes a change to the graduation process:
- each graduation application becomes a PR to add the project's application to the github repo
- TOC/SIGs/TAGs/CNCF members... can then review and ask for additional information to be added if needed
- once all information is provided, TOC members simply LGTM the PR and when 6 or more have done so it can then be added to the next TOC call for a formal vote. Unless people are comfortable with the LGTM/async voting process - which would be ideal.

My ask, if this direction seems reasonable, is that the TOC members propose additional items to the application template in this PR so that it eventually includes all information they will need to make their decision. I believe that aside from speeding up the process, it will also increase the transparency of the the process.

/cc @tomkerkhove