### PR TITLE
Update graduation_criteria.md

### DIFF
--- a/process/graduation_criteria.md
+++ b/process/graduation_criteria.md
@@ -14,6 +14,7 @@ To be accepted in the sandbox a project must
 * Adopt the CNCF [Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md)
 * Adhere to CNCF [IP Policy](https://github.com/cncf/foundation/blob/master/charter.md#11-ip-policy) (including trademark transferred)
 * List their sandbox status prominently on website/readme
+* Explicitly define a project governance and committer process. The committer process should cover the full committer lifecycle including onboarding and offboarding or emeritus criteria. This preferably is laid out in a GOVERNANCE.md file and references an OWNERS.md or MAINTAINERS.md file showing the current and emeritus committers. See https://contribute.cncf.io/maintainers/governance/ for more info.
 
 See the [CNCF Sandbox Guidelines v1.0](https://github.com/cncf/toc/blob/main/process/sandbox.md) for the detailed process.
 
@@ -24,8 +25,8 @@ See the [CNCF Sandbox Guidelines v1.0](https://github.com/cncf/toc/blob/main/pro
 To be accepted to incubating stage, a project must meet the sandbox stage requirements plus:
 
  * Document that it is being used successfully in production by at least three independent direct adopters which, in the TOC’s judgement, are of adequate quality and scope. For the definition of an adopter, see https://github.com/cncf/toc/blob/main/FAQ.md#what-is-the-definition-of-an-adopter.
-
  * Have a healthy number of committers. A committer is defined as someone with the commit bit; i.e., someone who can accept contributions to some or all of the project.
+ * Explicitly define the criteria, process and offboarding or emeritus conditions for project committers/maintainers; or those who may interact with the CNCF on behalf of the project. The list of maintainers should be preferably be stored in a MAINTAINERS.md file and audited at a minimum of an annual cadence.
  * Demonstrate a substantial ongoing flow of commits and merged contributions.
  * Since these metrics can vary significantly depending on the type, scope and size of a project, the TOC has final judgement over the level of activity that is adequate to meet these criteria
  * A clear versioning scheme.
@@ -39,7 +40,5 @@ To graduate from sandbox or incubating status, or for a new project to join as a
  * Have committers from at least two organizations.
  * Have achieved and maintained a Core Infrastructure Initiative [Best Practices Badge](https://bestpractices.coreinfrastructure.org/).
  * Have completed an independent and third party security audit with results published of similar scope and quality as the following example (including critical vulnerabilities addressed): https://github.com/envoyproxy/envoy#security-audit and all critical vulnerabilities need to be addressed before graduation.
- * Explicitly define a project governance and committer process. The committer process should cover the full committer lifecycle including onboarding and offboarding or emeritus criteria. This preferably is laid out in a GOVERNANCE.md file and references an OWNERS.md file showing the current and emeritus committers.
- * Explicitly define the criteria, process and offboarding or emeritus conditions for project maintainers; or those who may interact with the CNCF on behalf of the project. The list of maintainers should be preferably be stored in a MAINTAINERS.md file and audited at a minimum of an annual cadence.
  * Have a public list of project adopters for at least the primary repo (e.g., ADOPTERS.md or logos on the project website). For a specification, have a list of adopters for the implementation(s) of the spec.
  * Receive a supermajority vote from the TOC to move to graduation stage. Projects can attempt to move directly from sandbox to graduation, if they can demonstrate sufficient maturity. Projects can remain in an incubating state indefinitely, but they are normally expected to graduate within two years.


### PR DESCRIPTION
There have been some issues in CNCF where projects have waited too long to define basic governance processes, which have led to issues down the road as a project has scaled. It's better to encourage a project to start out with a simple governance structure in the beginning and evolve that over time versus starting with nothing and dealing with the aftermath of managing governance and growth at the same time.

There are also great resources and templates now that folks can lean on to craft their own governance https://contribute.cncf.io/maintainers/governance