### PR TITLE
Freeze updates

### DIFF
--- a/process/project_proposals.md
+++ b/process/project_proposals.md
@@ -15,60 +15,15 @@ This governance policy sets forth the proposal process for projects to be accept
 
 The TOC makes no guarantees on if or when a project will join the CNCF or move levels. Projects apply for moving levels when they feel they are ready. However, what is ready for one project is not the same for another nor is each project’s adoption and maturity measurable against one another. For some projects it may be a long journey with the TOC to bring them to maturity for the kind of project they are and for others it may be shorter - it all depends on the individual project, their readiness, and the availability of the individuals responsible for various tasks in moving levels.
 
-#### Expectations
+When projects apply for moving levels, they do not move levels on a first-in first-out (FIFO) basis. Some projects join the Foundation when they are already far along in their journey and others join very early. They will approach maturity guide posts differently - at different times and in ways similar or different from others. We do our best to support projects moving levels, in some cases engaging with them frequently to ensure they are making progress on our initial findings but leaving the application open.  In other cases, we review the project and finding nothing disparaging, only needing to refresh the content of the previous due diligence, evaluate against the next level of criteria, and move it forward.
 
-The TOC makes no guarantees on if or when a project will join the CNCF or move levels. Projects apply for moving levels when they feel they are ready. However, what is ready for one project is not the same for another nor is each project’s adoption and maturity measurable against one another. For some projects it may be a long journey with the TOC to bring them to maturity for the kind of project they are and for others it may be shorter - it all depends on the individual project, their readiness, and the availability of the individuals responsible for various tasks in moving levels.
-
-When projects apply for moving levels, they do not move levels on a first-in first-out (FIFO) basis. Some projects join the Foundation when they are already far along in their journey and others join very early. They will approach maturity guide posts differently - at different times and in different ways. We do our best to support projects moving levels, in some cases engaging with them frequently to ensure they are making progress on our initial findings but leaving the application open.  In other cases, we review the project and finding nothing disparaging, only needing to refresh the content of the previous due diligence, evaluate against the next level of criteria, and move it forward.
-
-For sandbox proposals, applications are reviewed from oldest application to newest every two months and the TOC may not have time to get through every application each meeting. The up to date list can be found [here](https://sandbox.cncf.io/) and will be carried over from meeting to meeting if not everyone is reviewed.
+For sandbox proposals, applications are reviewed in the order the TOC chooses, most commonly returning applications first and then from oldest application to newest every two months. The TOC may not have time to get through every application each meeting as different project applications carry varying considerations and discussion topics to ensure enough information is discovered and explored to make an informed decision. The up to date list can be found [here](https://sandbox.cncf.io/) and will be carried over from meeting to meeting if not every project is reviewed.
 
 For moving levels to incubation or graduation, projects should plan on _at least 5 months or more_ between the initial application and approval. 
 
 #### KubeCon+CloudNativeCon Freeze
 
-Due to the increased community demands around KubeCon + CloudNativeCon (KCCN), the scheduling and production of content, and reduced availability of individuals involved in moving levels, the TOC leverages a freeze for projects in process for moving levels. Even if a project is approved to move levels 3 weeks before this event, projects should _not_ expect to receive benefits beyond those afforded for the level they were previously at. For example, a sandbox project is approved to move to incubation 3 weeks prior to the event, they and the event staff will not have enough time to record, edit, and produce an incubating project update to have it included within the keynote stage reel.
-
-For each KubeCon + CloudNativeCon's (KCCN) standalone event — currently Europe and North America — the following freeze is applied:
-__Within 6 weeks of the event__
-* TOC members will not take on new sponsorship of applications for moving levels
-  * Many activities occur before, during, and after KCCN. Postponing new sponsorship until after KCCN reduces the likelihood that kicking off the process is overcome by such activities.
-__Within 2 weeks of the event__ 
-* Public Comment will not open
-  * We want to ensure community members, adopters, and other stakeholders have time to participate in the public comment of projects, the 2 weeks leading up to the event are typically very busy for many individuals involved in the moving levels process.
-* Voting for projects will not open
-  * Voting is an opportunity for community members to show support for projects, it is also the time when the TOC determines if the due diligence and state of the project support it's promotion to the next level. As such it is essential for TOC members to have time to not only cast votes, but to consider any comments raised during the public comment period. The TOC is just as busy as any other attendee or speaker for KCCN, it is easy to miss the timeframes for voting and we want to ensure projects receive the attention in a vote they deserve.
-* Open voting is paused
- * While community members may continue to show support for projects, the TOC will officially pause our voting.
-* No project announcements
- * Even if a project has passed a vote, if they have not announced and officially moved levels, they will not be included as an incubating or graduated project.
-__2nd week following the event__ 
-* Voting for projects who completed public comment may open and commence.
-  * The week immediately following KCCN is commonly reserved as a recovery and digest period for attendees, event staff, community members, and TOC. 
-
-TOC members may choose to continue working with projects on due diligence within the the weeks before and after KCCN subject to their and others' availability. Projects should take all of this into account when planning completion of their due diligence. We ask projects to be understanding and considerate of our availability constraints around KCCN and remind everyone that the TOC is not a full-time body, we have primary work commitments in addition to our involvement on the TOC and any projects, TAGs, or community groups we are involved in.
-
-#### Additional information
-
-Q: Why doesn't the TOC get through the sandbox list every meeting?
-A: There are currently many projects that want to be a part of the CNCF and it is the TOC's job to carefully consider if they are the right fit for the foundation. This deliberation takes times and there are only so many applications that the TOC can get through each meeting. If anything, a delay from one meeting to the next is a benefit for the project because it allows more time to build community support.
-
-Q: Exactly how long will it take my project to move levels once my application is in?
-A: Just like in open source, it will get done when the work is done. This can range from 5 months to 15 months please coordinate with your TOC sponsor to keep everything on track.
-
-Q: Can my project still apply to move levels within 6 weeks of KubeCon?
-A: Yes, though getting a TOC sponsor, conducting any due dilligence, and any other steps of the process will be delayed until after KubeCon.
-
-Q: Why can't public comment periods or votes launch within 6 weeks of a KubeCon?
-A: Undergoing due diligence is non-insignificant amount of work. Conducting adopter interviews takes time and scheduling becomes increasingly difficult the closer to each KCCN we get. Being able to successfully complete due diligence to launch the public part of the process becomes very difficult as many community members have additional responsibilites related to the conference. By removing KCCN as a goal post for brand new requests to move levels, we hope to not burn out adopters, TOC, maintainers, and other community members.committthe Foundation when they are already far along in their journey and others join very early. They will approach maturity guide posts differently - at different times and in different ways. We do our best to support projects moving levels, in some cases engaging with them frequently to ensure they are making progress on our initial findings but leaving the application open.  In other cases, we review the project and finding nothing disparaging, only needing to refresh the content of the previous due diligence, evaluate against the next level of criteria, and move it forward.
-
-For sandbox proposals, applications are reviewed from oldest application to newest every two months and the TOC may not have time to get through every application each meeting. The up to date list can be found [here](https://sandbox.cncf.io/) and will be carried over from meeting to meeting if not every one is reviewed.
-
-For moving levels to incubation or graduation, projects should plan on _at least 5 months or more_ between the initial application and approval. 
-
-#### KubeCon+CloudNativeCon Freeze
-
-Due to the increased community demands around KubeCon + CloudNativeCon (KCCN), the scheduling and production of content, and reduced availability of individuals involved in moving levels, the TOC leverages a freeze for projects in process for moving levels. Even if a project is approved to move levels 3 weeks before this event, projects should _not_ expect to receive benefits beyond those afforded for the level they were previously at. For example, if a sandbox project is approved to move to incubation 3 weeks prior to the event, they and the event staff will not have enough time to record, edit, and produce an incubating project update to have it included within the keynote stage reel.
+Due to the increased community demands around KubeCon + CloudNativeCon (KCCN), the scheduling and production of content, and reduced availability of individuals involved in moving levels, the TOC leverages a freeze for projects in process for moving levels. Even if a project is approved to move levels 3 weeks before this event, projects should _not_ expect to receive benefits beyond those afforded for the level they were previously at. For example, if a sandbox project is approved to move to incubation 3 weeks prior to the event, the project and the event staff will not have enough time to record, edit, and produce an incubating project update to have it included within the keynote stage reel.
 
 For each KubeCon + CloudNativeCon's (KCCN) standalone event — currently Europe and North America — the following freeze is applied:
 __Within 6 weeks of the event__

--- a/process/project_proposals.md
+++ b/process/project_proposals.md
@@ -11,11 +11,44 @@ This governance policy sets forth the proposal process for projects to be accept
 
 ### Timelines
 
-The TOC makes no guarantees on if/when a project will join the CNCF or move levels.
+#### Expectations
 
-For sandbox proposals, applications are reviewed from oldest application to newest every two months and the TOC may not have time to get through every application each meeting. The up to date list can be found [here](https://sandbox.cncf.io/) and will be carried over from meeting to meeting if not every one is reviewed.
+The TOC makes no guarantees on if or when a project will join the CNCF or move levels. Projects apply for moving levels when they feel they are ready. However, what is ready for one project is not the same for another nor is each project’s adoption and maturity measurable against one another. For some projects it may be a long journey with the TOC to bring them to maturity for the kind of project they are and for others it may be shorter - it all depends on the individual project, their readiness, and the availability of the individuals responsible for various tasks in moving levels.
 
-For moving levels to incubation or graduation, projects should plan on at least 5 months or more between the initial application and approval. Due to the increased community demands around KubeCon + CloudNativeCon, new public comment periods and public votes will not launch within 6 weeks of a KubeCon + CloudNativeCon. Project should take this into account when planning completion of their due diligence.
+#### Expectations
+
+The TOC makes no guarantees on if or when a project will join the CNCF or move levels. Projects apply for moving levels when they feel they are ready. However, what is ready for one project is not the same for another nor is each project’s adoption and maturity measurable against one another. For some projects it may be a long journey with the TOC to bring them to maturity for the kind of project they are and for others it may be shorter - it all depends on the individual project, their readiness, and the availability of the individuals responsible for various tasks in moving levels.
+
+When projects apply for moving levels, they do not move levels on a first-in first-out (FIFO) basis. Some projects join the Foundation when they are already far along in their journey and others join very early. They will approach maturity guide posts differently - at different times and in different ways. We do our best to support projects moving levels, in some cases engaging with them frequently to ensure they are making progress on our initial findings but leaving the application open.  In other cases, we review the project and finding nothing disparaging, only needing to refresh the content of the previous due diligence, evaluate against the next level of criteria, and move it forward.
+
+For sandbox proposals, applications are reviewed from oldest application to newest every two months and the TOC may not have time to get through every application each meeting. The up to date list can be found [here](https://sandbox.cncf.io/) and will be carried over from meeting to meeting if not everyone is reviewed.
+
+For moving levels to incubation or graduation, projects should plan on _at least 5 months or more_ between the initial application and approval. 
+
+#### KubeCon+CloudNativeCon Freeze
+
+Due to the increased community demands around KubeCon + CloudNativeCon (KCCN), the scheduling and production of content, and reduced availability of individuals involved in moving levels, the TOC leverages a freeze for projects in process for moving levels. Even if a project is approved to move levels 3 weeks before this event, projects should _not_ expect to receive benefits beyond those afforded for the level they were previously at. For example, a sandbox project is approved to move to incubation 3 weeks prior to the event, they and the event staff will not have enough time to record, edit, and produce an incubating project update to have it included within the keynote stage reel.
+
+For each KubeCon + CloudNativeCon's (KCCN) standalone event — currently Europe and North America — the following freeze is applied:
+__Within 6 weeks of the event__
+* TOC members will not take on new sponsorship of applications for moving levels
+  * Many activities occur before, during, and after KCCN. Postponing new sponsorship until after KCCN reduces the likelihood that kicking off the process is overcome by such activities.
+__Within 2 weeks of the event__ 
+* Public Comment will not open
+  * We want to ensure community members, adopters, and other stakeholders have time to participate in the public comment of projects, the 2 weeks leading up to the event are typically very busy for many individuals involved in the moving levels process.
+* Voting for projects will not open
+  * Voting is an opportunity for community members to show support for projects, it is also the time when the TOC determines if the due diligence and state of the project support it's promotion to the next level. As such it is essential for TOC members to have time to not only cast votes, but to consider any comments raised during the public comment period. The TOC is just as busy as any other attendee or speaker for KCCN, it is easy to miss the timeframes for voting and we want to ensure projects receive the attention in a vote they deserve.
+* Open voting is paused
+ * While community members may continue to show support for projects, the TOC will officially pause our voting.
+* No project announcements
+ * Even if a project has passed a vote, if they have not announced and officially moved levels, they will not be included as an incubating or graduated project.
+__2nd week following the event__ 
+* Voting for projects who completed public comment may open and commence.
+  * The week immediately following KCCN is commonly reserved as a recovery and digest period for attendees, event staff, community members, and TOC. 
+
+TOC members may choose to continue working with projects on due diligence within the the weeks before and after KCCN subject to their and others' availability. Projects should take all of this into account when planning completion of their due diligence. We ask projects to be understanding and considerate of our availability constraints around KCCN and remind everyone that the TOC is not a full-time body, we have primary work commitments in addition to our involvement on the TOC and any projects, TAGs, or community groups we are involved in.
+
+#### Additional information
 
 Q: Why doesn't the TOC get through the sandbox list every meeting?
 A: There are currently many projects that want to be a part of the CNCF and it is the TOC's job to carefully consider if they are the right fit for the foundation. This deliberation takes times and there are only so many applications that the TOC can get through each meeting. If anything, a delay from one meeting to the next is a benefit for the project because it allows more time to build community support.
@@ -27,7 +60,48 @@ Q: Can my project still apply to move levels within 6 weeks of KubeCon?
 A: Yes, though getting a TOC sponsor, conducting any due dilligence, and any other steps of the process will be delayed until after KubeCon.
 
 Q: Why can't public comment periods or votes launch within 6 weeks of a KubeCon?
-A: Undergoing due diligence is non-insignificant amount of work. Conducting adopter interviews takes time and scheduling becomes increasingly difficult the closer to each KCCN we get. Being able to successfully complete due diligence to launch the public part of the process becomes very difficult as many community members have additional responsibilites related to the conference. By removing KCCN as a goal post for brand new requests to move levels, we hope to not burn out adopters, TOC, maintainers, and other community members.
+A: Undergoing due diligence is non-insignificant amount of work. Conducting adopter interviews takes time and scheduling becomes increasingly difficult the closer to each KCCN we get. Being able to successfully complete due diligence to launch the public part of the process becomes very difficult as many community members have additional responsibilites related to the conference. By removing KCCN as a goal post for brand new requests to move levels, we hope to not burn out adopters, TOC, maintainers, and other community members.committthe Foundation when they are already far along in their journey and others join very early. They will approach maturity guide posts differently - at different times and in different ways. We do our best to support projects moving levels, in some cases engaging with them frequently to ensure they are making progress on our initial findings but leaving the application open.  In other cases, we review the project and finding nothing disparaging, only needing to refresh the content of the previous due diligence, evaluate against the next level of criteria, and move it forward.
+
+For sandbox proposals, applications are reviewed from oldest application to newest every two months and the TOC may not have time to get through every application each meeting. The up to date list can be found [here](https://sandbox.cncf.io/) and will be carried over from meeting to meeting if not every one is reviewed.
+
+For moving levels to incubation or graduation, projects should plan on _at least 5 months or more_ between the initial application and approval. 
+
+#### KubeCon+CloudNativeCon Freeze
+
+Due to the increased community demands around KubeCon + CloudNativeCon (KCCN), the scheduling and production of content, and reduced availability of individuals involved in moving levels, the TOC leverages a freeze for projects in process for moving levels. Even if a project is approved to move levels 3 weeks before this event, projects should _not_ expect to receive benefits beyond those afforded for the level they were previously at. For example, if a sandbox project is approved to move to incubation 3 weeks prior to the event, they and the event staff will not have enough time to record, edit, and produce an incubating project update to have it included within the keynote stage reel.
+
+For each KubeCon + CloudNativeCon's (KCCN) standalone event — currently Europe and North America — the following freeze is applied:
+__Within 6 weeks of the event__
+* TOC members will not take on new sponsorship of applications for moving levels
+ * Many activities occur before, during, and after KCCN. Postponing new sponsorship until after KCCN reduces the likelihood that kicking off the process is overcome by such activities.
+__Within 2 weeks of the event__
+* Public Comment will not open
+ * We want to ensure community members, adopters, and other stakeholders have time to participate in the public comment of projects, the 2 weeks leading up to the event are typically very busy for many individuals involved in the moving levels process.
+* Voting for projects will not open
+ * Voting is an opportunity for community members to show support for projects, it is also the time when the TOC determines if the due diligence and state of the project support its promotion to the next level. As such it is essential for TOC members to have time to not only cast votes, but to consider any comments raised during the public comment period. The TOC is just as busy as any other attendee or speaker for KCCN, it is easy to miss the timeframes for voting and we want to ensure projects receive the attention in a vote they deserve.
+* Open voting is paused
+ * While community members may continue to show support for projects, the TOC will officially pause our voting.
+* No project announcements
+ * Even if a project has passed a vote, if they have not announced and officially moved levels, they will not be included as an incubating or graduated project.
+__2nd week following the event__
+* Voting for projects who completed public comment may open and commence.
+ * The week immediately following KCCN is commonly reserved as a recovery and digest period for attendees, event staff, community members, and TOC.
+
+TOC members may choose to continue working with projects on due diligence within the weeks before and after KCCN subject to their and others' availability. Projects should take all of this into account when planning completion of their due diligence. We ask projects to be understanding and considerate of our availability constraints around KCCN and remind everyone that the TOC is not a full-time body, we have primary work commitments in addition to our involvement on the TOC and any projects, TAGs, or community groups we are involved in.
+
+#### Additional information
+
+Q: Why doesn't the TOC get through the sandbox list every meeting?
+A: There are currently many projects that want to be a part of the CNCF and it is the TOC's job to carefully consider if they are the right fit for the foundation. This deliberation takes time and there are only so many applications that the TOC can get through each meeting. If anything, a delay from one meeting to the next is a benefit for the project because it allows more time to build community support.
+
+Q: Exactly how long will it take my project to move levels once my application is in?
+A: Just like in open source, it will get done when the work is done. This can range from 5 months to 15 months please coordinate with your TOC sponsor to keep everything on track.
+
+Q: Can my project still apply to move levels within 6 weeks of KubeCon?
+A: Yes, though getting a TOC sponsor, conducting any due diligence, and any other steps of the process will be delayed until after KubeCon.
+
+Q: Why can't public comment periods or votes launch within 6 weeks of a KubeCon?
+A: Undergoing due diligence is a non-insignificant amount of work. Conducting adopter interviews takes time and scheduling becomes increasingly difficult the closer to each KCCN we get. Being able to successfully complete due diligence to launch the public part of the process becomes very difficult as many community members have additional responsibilities related to the conference. By removing KCCN as a goal post for brand new requests to move levels, we hope to not burn out adopters, TOC, maintainers, and other community members.
 
 ### Sandbox process
 


### PR DESCRIPTION
What: Pull in the general steps for moving levels
Why:

* Some projects shared it was not clear what was next or who was responsible for performing it.

This change addresses the need by:

* adding General steps section
* documenting general steps
* document the "who" for general steps
