### PR TITLE
Bootstrap files to document the TAG formation

### DIFF
--- a/tags/resources/faq-tag-formation-lessons-learned.md
+++ b/tags/resources/faq-tag-formation-lessons-learned.md
@@ -1,0 +1,3 @@
+# FAQ lessons learned from other TAGs
+
+*tbd* - contributions are welcome!

--- a/tags/resources/tag-formation-guides/README.md
+++ b/tags/resources/tag-formation-guides/README.md
@@ -1,0 +1,8 @@
+# TAG formation Guides
+
+This folder contains guides on how to form a CNCF TAG.
+This [file](https://github.com/cncf/toc/blob/main/tags/cncf-tags.md) provides an overview of CNCF's Technical Advisory Groups (TAGs), their purpose, responsibilities, and operations.
+
+**Guides**:
+- [TAG charter document writing guide](guide-tag-formation-roadmap.md)
+- [TAG formation Road Map](guide-writing-charter.md)

--- a/tags/resources/tag-formation-guides/guide-tag-formation-roadmap.md
+++ b/tags/resources/tag-formation-guides/guide-tag-formation-roadmap.md
@@ -1,0 +1,3 @@
+# TAG formation Road Map
+
+*tbd* - contributions are welcome!

--- a/tags/resources/tag-formation-guides/guide-writing-charter.md
+++ b/tags/resources/tag-formation-guides/guide-writing-charter.md
@@ -1,0 +1,3 @@
+# TAG charter document writing guide
+
+*tbd* - contributions are welcome!

--- a/tags/resources/tag-formation-templates/README.md
+++ b/tags/resources/tag-formation-templates/README.md
@@ -1,0 +1,13 @@
+# TAG formation templates
+
+This folder contains templates that can serve as a foundation for new TAGs to help them build their governance structures or for existing TAGs to refine their structures.
+The files have placeholders marked with `<TAG-NAME>` or similar.
+
+**Templates**:
+- [Artifact publishing guidelines](template-artifact-publishing-guidelines.md)
+- [Blog post process](template-blog-post-process.md)
+- [CONTRIBUTING](template-contributing.md)
+- [Leadership election process](template-leadership-election-process.md)
+- [Leadership Structure](template-leadership-structure.md)
+- [TAG Roles](template-roles.md)
+- [Whitepaper process](template-whitepaper-process.md)

--- a/tags/resources/tag-formation-templates/template-artifact-publishing-guidelines.md
+++ b/tags/resources/tag-formation-templates/template-artifact-publishing-guidelines.md
@@ -1,0 +1,3 @@
+# Artifact Publishing Guidelines for the `<TAG NAME>`
+
+*tbd* - contributions are welcome!

--- a/tags/resources/tag-formation-templates/template-blog-post-process.md
+++ b/tags/resources/tag-formation-templates/template-blog-post-process.md
@@ -1,0 +1,3 @@
+# Blog Post process within the `<TAG NAME>`
+
+*tbd* - contributions are welcome!

--- a/tags/resources/tag-formation-templates/template-contributing.md
+++ b/tags/resources/tag-formation-templates/template-contributing.md
@@ -1,0 +1,3 @@
+# Roles within the `<TAG NAME>`
+
+*tbd* - contributions are welcome!

--- a/tags/resources/tag-formation-templates/template-leadership-election-process.md
+++ b/tags/resources/tag-formation-templates/template-leadership-election-process.md
@@ -1,0 +1,3 @@
+# Leadership election process within the `<TAG NAME>`
+
+*tbd* - contributions are welcome!

--- a/tags/resources/tag-formation-templates/template-leadership-structure.md
+++ b/tags/resources/tag-formation-templates/template-leadership-structure.md
@@ -1,0 +1,3 @@
+# Leadership structure within the `<TAG NAME>`
+
+*tbd* - contributions are welcome!

--- a/tags/resources/tag-formation-templates/template-roles.md
+++ b/tags/resources/tag-formation-templates/template-roles.md
@@ -1,0 +1,3 @@
+# Roles within the `<TAG NAME>`
+
+*tbd* - contributions are welcome!

--- a/tags/resources/tag-formation-templates/template-whitepaper-process.md
+++ b/tags/resources/tag-formation-templates/template-whitepaper-process.md
@@ -1,0 +1,3 @@
+# Whitepaper process within the `<TAG NAME>`
+
+*tbd* - contributions are welcome!

--- a/tags/resources/toc-supporting-guides/README.md
+++ b/tags/resources/toc-supporting-guides/README.md
@@ -1,0 +1,7 @@
+# TOC Supporting Guides for TAGs
+
+The TOC has a number of [tasks](https://github.com/cncf/toc/tree/main/process) that it performs. TAGs act as an extension of the TOC in certain areas, as described [here](https://github.com/cncf/toc/blob/main/tags/cncf-tags.md).
+This folder contains guides on how TAGs can support the TOC.
+
+**Guides**:
+- [Project reviews](project-reviews.md)

--- a/tags/resources/toc-supporting-guides/project-reviews.md
+++ b/tags/resources/toc-supporting-guides/project-reviews.md
@@ -1,0 +1,3 @@
+# How TAGs help with project reviews
+
+*tbd* - contributions are welcome!


### PR DESCRIPTION
This PR adds folders and files to `cncf/toc/tags/resources/***` documenting templates and guides used to form TAGs and supporting files used by TAGs to support the TOC.

The files are marked with `*tbd* - contributions are welcome!`, the contents are added in upcoming PRs. Establishing the structure and stub files should make it easier to collaborate on this effort.

This has been coordinated with the issue #1043 see [comment](https://github.com/cncf/toc/issues/1043#issuecomment-1584965663).

cc @TheFoxAtWork 