### PR TITLE
feat: Introduce issue contact links to guide community members

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -9,6 +9,3 @@ contact_links:
   - name: Explore Incubation Backlog
     url: https://github.com/cncf/toc/projects/7?query=is%3Aopen+sort%3Aupdated-desc
     about: View the current backlog of projects proposing to transition to CNCF Incubation
-  - name: Open a ticket with CNCF Service Desk
-    url: http://servicedesk.cncf.io/
-    about: Get support from CNCF through the service desk (https://github.com/cncf/servicedesk)

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,14 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Join the CNCF TOC mailing list
+    url: https://lists.cncf.io/g/cncf-toc
+    about: Join the public mailing list around CNCF Technical Oversight Committee (TOC)
+  - name: Explore Graduation Backlog
+    url: https://github.com/cncf/toc/projects/6?query=is%3Aopen+sort%3Aupdated-desc
+    about: View the current backlog of projects proposing to transition to CNCF Graduation
+  - name: Explore Incubation Backlog
+    url: https://github.com/cncf/toc/projects/7?query=is%3Aopen+sort%3Aupdated-desc
+    about: View the current backlog of projects proposing to transition to CNCF Incubation
+  - name: Open a ticket with CNCF Service Desk
+    url: http://servicedesk.cncf.io/
+    about: Get support from CNCF through the service desk (https://github.com/cncf/servicedesk)


### PR DESCRIPTION
Introduce issue contact links to guide community members in finding what they need.

Example from KEDA (note "Open" links):
![image](https://github.com/cncf/toc/assets/4345663/50e7a98f-6845-4a60-81b8-db4f644c4748)
