### PR TITLE
proposal: Automatically post voting results every week

### DIFF
--- a/.gitvote.yml
+++ b/.gitvote.yml
@@ -2,6 +2,7 @@ profiles:
   default:
     duration: 26w
     pass_threshold: 66
+    periodic_status_check: "1 week"
     allowed_voters:
       teams:
         - cncf-toc


### PR DESCRIPTION
Automatically post voting results every week so that community can track progress without having to post the command.

Relates to https://github.com/cncf/gitvote/issues/162