### PR TITLE
Update archival process to update CLOMonitor

### DIFF
--- a/.github/ISSUE_TEMPLATE/archived.md
+++ b/.github/ISSUE_TEMPLATE/archived.md
@@ -18,3 +18,4 @@ assignees: caniszczyk, amye, idvoretskyi, jeefy
 - [ ] Notify Speakers team to remove from CFPs	
 - [ ] Remove from service desk or archive	
 - [ ] Remove from CNCF store
+- [ ] Remove from [CLOMonitor data](https://raw.githubusercontent.com/cncf/clomonitor/main/data/cncf.yaml)


### PR DESCRIPTION
For example, Open Service Mesh is archived here (https://github.com/cncf/toc/issues/1104) but it still exists in CLOMonitor.

cc @tegioz