### PR TITLE
Document TAG Roles - TAG governance template file

### DIFF
--- a/tags/resources/tag-formation-templates/template-leadership-election-process.md
+++ b/tags/resources/tag-formation-templates/template-leadership-election-process.md
@@ -1,15 +1,3 @@
 # Leadership election process within the `<TAG NAME>`
 
 *tbd* - contributions are welcome!
-
-## Chair
-
-*tbd* - contributions are welcome!
-
-## Technical Lead
-
-*tbd* - contributions are welcome!
-
-## Working Group Lead
-
-*tbd* - contributions are welcome!

--- a/tags/resources/tag-formation-templates/template-leadership-election-process.md
+++ b/tags/resources/tag-formation-templates/template-leadership-election-process.md
@@ -1,3 +1,15 @@
 # Leadership election process within the `<TAG NAME>`
 
 *tbd* - contributions are welcome!
+
+## Chair
+
+*tbd* - contributions are welcome!
+
+## Technical Lead
+
+*tbd* - contributions are welcome!
+
+## Working Group Lead
+
+*tbd* - contributions are welcome!

--- a/tags/resources/tag-formation-templates/template-roles.md
+++ b/tags/resources/tag-formation-templates/template-roles.md
@@ -8,8 +8,7 @@ Beyond the roles described in this document the TAG has many contributors, all s
 - [Roles within the `<TAG NAME>`](#roles-within-the-tag-name)
   - [Chairs](#chairs)
   - [Technical lead](#technical-lead)
-  - [Working Group Lead](#working-group-lead)
-  - [Project Lead](#project-lead)
+  - [Working Group or Project Lead](#working-group-or-project-lead)
   - [TOC liaison](#toc-liaison)
   - [Emeritus Chair](#emeritus-chair)
 
@@ -42,7 +41,7 @@ For more information on TAG Chair responsibilities and expectations, please refe
 ## Technical lead
 
 A technical lead (TL) expands the bandwidth of the leadership team in terms of covering technical areas, growing the community, organizing events or doing TAG communications.
-Proposals must have a TL or Chair working as an active sponsor.
+Applications must have a TL or Chair working as an active sponsor.
 TLs are experienced contributors within TAG, often recognized as successful past project leads, through their triage and planning, content and community management, or other attributes the Chairs determine to be valued for the TAG. TLs may be term limited akin to Chairs, the recommended time-frame is two years, but is dependent upon each TAG to define as their needs and activities warrant.
 Technical leads go through an [election process](https://github.com/cncf/toc/blob/master/tags/cncf-tags.md#elections) with a final CNCF TOC vote.
 The [leadership election process is described here](template-leadership-election-process.md#technical-lead).
@@ -60,40 +59,27 @@ The [leadership election process is described here](template-leadership-election
 
 ## Working Group or Project Lead
 
-Depending on the nature of the work being pursued by the TAG, the TAG Leadership may determine, with TOC liaison approval, that a particular project or effort warrants a working group. A working group or project lead(s) is an experienced contributor to the TAG that volunteers to lead a scoped activity and group alongside one or two others.  The number of leads may vary greatly depending on the defined scope and level of effort. Working Group or Project Leads are confirmed by the TAG Leadership and coordinate closely with the TAG Leadership sponsor for the group to keep them apprised of the group's progress and deliverables.
-Working groups as community governance structure are defined in the [CNCF TAG](https://github.com/cncf/toc/blob/master/tags) folder.
-TAG Leadership is responsible facilitating the working group applications and ensuring the group's work is done transparently, in a manner accessible and traceable for everyone.
-One of the TAG Leadership team (may be a Chair or TL) serves as the group sponsor and provides guidance to the group leads.
-Group leads are signed off by the TAG Chairs, the approval of the working group is given by TOC Liaisons. Should a group need to exist in perpetuity, the TAG Leadership is expected to provide term-limits or opportunities to rotate WG leadership as part of their governance.
+Depending on the nature of the work being pursued by the TAG, the TAG Leadership may determine, with TOC Liaison approval, that a particular project or effort warrants a longer term project.
+Working Groups as community governance structure are defined in the [CNCF TOC](https://github.com/cncf/toc/tree/main/workinggroups) repository.
+Unlike Working Groups, Projects require a predetermined time frame and are limited in scope and focused on a central deliverable.
 
-**A working group lead is expected to**:
-* Schedule, host, plan and facilitate meetings for the working group.
-* Provide technical direction unique to the working group.
-* Plan working group deliverables.
-* Report to the TAG on the working group status.
-* Evolve the working group.
+A Working Group or Project Lead(s) is an experienced contributor to the TAG that volunteers to lead a scoped activity and group alongside one or two others.
+The number of leads may vary greatly depending on the defined scope and level of effort.
+Working Group or Project Leads are confirmed by the TAG Leadership and coordinate closely with the TAG Leadership sponsor for the group to keep them apprised of the group's progress and deliverables.
+TAG Leadership is responsible for facilitating the group lead applications and ensuring the group's work is done transparently, in a manner accessible and traceable for everyone.
+One of the TAG Leadership team (maybe a Chair or TL) serves as the group sponsor and provides guidance to the group leads.
+Working Group or Project Lead(s) are signed off by the TAG Chairs, the approval is given by TOC Liaisons.
+Should a group need to exist in perpetuity, the TAG Leadership is expected to provide term-limits or opportunities to rotate group leadership as part of their governance.
+
+**The tasks of a working group lead or project lead may include the following**:
+* Schedule, host, plan and facilitate meetings for the group.
+* Provide technical direction unique to the group.
+* Plan group deliverables.
+* Report to the TAG on the group status.
 * Garner active participation.
 * Establish documents and correct permissions for contributions to occur.
-* Contribute content to the working group.
-* Onboard and setup the working group lead successor.
-
-## Project Lead
-
-A project lead manages a community group for a specified period of time and works to achieve a specific outcome that has been previously discussed and agreed upon.
-Unlike working groups, projects require a predetermined time frame and are limited in scope and focused on a central deliverable. The project proposal must be discussed at a meeting and actively communicated to the entire TAG community.
-A TAG Chair or TL acts as a sponsor of the project and dedicates a portion of their time to actively support the effort.
-TAG Chairs must sign off on the establishment of the project group.
-Due to the limited scope of the role, there are no specific requirements for structuring the selection process for the project lead.  
-The TAG Chairs are responsible for selecting a suitable project lead and must ensure that the establishment of the project is transparent, accessible, and understood by all.
-
-**A project lead is expected to**:
-* Schedule, host, plan and facilitate meetings for the project.
-* Provide technical direction unique to the project.
-* Plan the project deliverable.
-* Report to the TAG on the project status.
-* Garner active participation.
-* Establish documents and correct permissions for contributions to occur.
-* Contribute content to the project.
+* Contribute content to the group.
+* Onboard and setup the group lead successor.
 
 ## TOC liaison
 

--- a/tags/resources/tag-formation-templates/template-roles.md
+++ b/tags/resources/tag-formation-templates/template-roles.md
@@ -7,9 +7,11 @@ Beyond the roles described in this document the TAG has many contributors, all s
 
 - [Roles within the `<TAG NAME>`](#roles-within-the-tag-name)
   - [Chairs](#chairs)
-  - [Technical lead](#technical-lead)
-  - [Working Group or Project Lead](#working-group-or-project-lead)
+  - [Technical lead (TL)](#technical-lead-tl)
+  - [Working Group Chair](#working-group-chair)
+  - [Working Group technical lead](#working-group-technical-lead)
   - [TOC liaison](#toc-liaison)
+  - [WG TAG Lead Liasion](#wg-tag-lead-liasion)
   - [Emeritus Chair](#emeritus-chair)
 
 ## Chairs
@@ -17,9 +19,7 @@ Beyond the roles described in this document the TAG has many contributors, all s
 The TAG Chairs drive, guide, and coordinate the TAG's efforts within the broader CNCF ecosystem and within their TAG's community. They are supported by Technical Leads in the execution of TAG activities
 Chairs may be experienced leaders within the CNCF ecosystem and often have specialized domain expertise. Chairs have term limits, most commonly two years. Chairs continue to serve until removed either by an elected replacement or by the TOC.
 
-Chair applications go through an [election process](https://github.com/cncf/toc/blob/master/tags/cncf-tags.md#elections) with a final CNCF TOC vote.
-
-The [leadership election process is described here](template-leadership-election-process.md#chair).
+Chair applications go through an [election process](https://github.com/cncf/toc/blob/master/tags/cncf-tags.md#elections) with a final CNCF TOC vote. The [leadership election process is described here](template-leadership-election-process.md#chair).
 
 Chair responsibilities and expectations may include the following or delegation of the following: 
 * Manage the operations and governance of the group.
@@ -32,19 +32,16 @@ Chair responsibilities and expectations may include the following or delegation 
 * Evolve the TAG to reflect ongoing changes in the industry.
 * Onboard and mentor new community members.
 * Mentor community members in a leadership role within the TAG.
-* Enforce and promote diversity in TAG work.
-* Enforce and promote good communication in TAG efforts in accordance with the [CNCF CoC](https://www.cncf.io/conduct/)
+* Enforce and promote the [CNCF CoC](https://www.cncf.io/conduct/) and our shared community values.
 * Embody and promote excellent leadership in accordance with the [Technical Leadership principles](https://github.com/cncf/toc/blob/main/PRINCIPLES.md#technical-leadership-principles)
 
 For more information on TAG Chair responsibilities and expectations, please refer the to the TOC's description of [TAG Chairs](placeholder)
 
-## Technical lead
+## Technical lead (TL)
 
 A technical lead (TL) expands the bandwidth of the leadership team in terms of covering technical areas, growing the community, organizing events or doing TAG communications.
-Applications must have a TL or Chair working as an active sponsor.
-TLs are experienced contributors within TAG, often recognized as successful past project leads, through their triage and planning, content and community management, or other attributes the Chairs determine to be valued for the TAG. TLs may be term limited akin to Chairs, the recommended time-frame is two years, but is dependent upon each TAG to define as their needs and activities warrant.
-Technical leads go through an [election process](https://github.com/cncf/toc/blob/master/tags/cncf-tags.md#elections) with a final CNCF TOC vote.
-The [leadership election process is described here](template-leadership-election-process.md#technical-lead).
+Working Groups must have a TL or Chair working as an active sponsor.
+TLs are experienced contributors within TAG, often recognized as successful past project leads, through their triage and planning, content and community management, or other attributes the Chairs determine to be valued for the TAG. TLs may be term limited akin to Chairs, the recommended time-frame is two years, but is dependent upon each TAG to define as their needs and activities warrant. The [leadership election process for TLs is described here](template-leadership-election-process.md#technical-lead) <!-- UPDATE LINK AFTER THE TEMPLATE HAS BEEN COPIED -->.
 
 **A technical lead is expected to**:
 * Establish and guide projects and working groups.
@@ -53,23 +50,15 @@ The [leadership election process is described here](template-leadership-election
 * Serving as TAG leadership representative in CNCF project discussions and on community events.
 * Onboard and mentor new community members.
 * Mentor community members in a leadership role within the TAG.
-* Enforce and encourage diversity in the TAG efforts.
-* Enforce and encourage good communication in the TAG efforts following the [CNCF CoC](https://www.cncf.io/conduct/).
+* Enforce and promote the [CNCF CoC](https://www.cncf.io/conduct/) and our shared community values.
 * Support the TAG Chairs.
 
-## Working Group or Project Lead
+## Working Group Chair
 
 Depending on the nature of the work being pursued by the TAG, the TAG Leadership may determine, with TOC Liaison approval, that a particular project or effort warrants a longer term project.
 Working Groups as community governance structure are defined in the [CNCF TOC](https://github.com/cncf/toc/tree/main/workinggroups) repository.
-Unlike Working Groups, Projects require a predetermined time frame and are limited in scope and focused on a central deliverable.
 
-A Working Group or Project Lead(s) is an experienced contributor to the TAG that volunteers to lead a scoped activity and group alongside one or two others.
-The number of leads may vary greatly depending on the defined scope and level of effort.
-Working Group or Project Leads are confirmed by the TAG Leadership and coordinate closely with the TAG Leadership sponsor for the group to keep them apprised of the group's progress and deliverables.
-TAG Leadership is responsible for facilitating the group lead applications and ensuring the group's work is done transparently, in a manner accessible and traceable for everyone.
-One of the TAG Leadership team (maybe a Chair or TL) serves as the group sponsor and provides guidance to the group leads.
-Working Group or Project Lead(s) are signed off by the TAG Chairs, the approval is given by TOC Liaisons.
-Should a group need to exist in perpetuity, the TAG Leadership is expected to provide term-limits or opportunities to rotate group leadership as part of their governance.
+A Working Group technical lead is an experienced contributor to the TAG that volunteers to lead and steer a scoped activity. Each WG has between two and three chairs. The [WG Chair election process is described here](template-leadership-election-process.md). <!-- UPDATE LINK AFTER THE TEMPLATE HAS BEEN COPIED -->
 
 **The tasks of a working group lead or project lead may include the following**:
 * Schedule, host, plan and facilitate meetings for the group.
@@ -79,7 +68,21 @@ Should a group need to exist in perpetuity, the TAG Leadership is expected to pr
 * Garner active participation.
 * Establish documents and correct permissions for contributions to occur.
 * Contribute content to the group.
-* Onboard and setup the group lead successor.
+* Onboard and setup a WG Chair successors.
+
+## Working Group technical lead
+
+A Working Group technical lead is an experienced contributor to the TAG that volunteers to lead a scoped activity in support to the WG Chairs.
+The number of WG TLs may vary depending on the defined scope and level of effort.
+The [WG TL election process is described here](template-leadership-election-process.md). <!-- UPDATE LINK AFTER THE TEMPLATE HAS BEEN COPIED -->
+
+**The tasks of a working group lead or project lead may include the following**:
+* Provide technical direction unique to the group.
+* Collaborate on group deliverables.
+* Report to the TAG on the group status.
+* Garner active participation.
+* Contribute content to the group.
+* Onboard and setup WG TL successors.
 
 ## TOC liaison
 
@@ -88,7 +91,11 @@ The TAG Chairs are responsible for establishing effective communication with the
 
 The TOC Liaison will occasionally prioritize TAG activities, as needed by the TOC, to further the [CNCF mission](https://github.com/cncf/foundation/blob/master/charter.md#1-mission-of-the-cloud-native-computing-foundation).
 
-For more information on TOC Liaisons, their responsibilities and expectations, please refer to the [TOC Liaisons section of CNCF Tags](https://github.com/cncf/toc/blob/main/tags/cncf-tags.md#toc-liaisons).
+For more information on TOC Liaisons, their responsibilities and expectations, please refer to the [TOC Liaisons section of CNCF Tags](https://github.com/cncf/toc/tree/main/tags#toc-liaisons).
+
+## WG TAG Lead Liasion
+
+Following the TOC liaison for TAG model, at least one TAG co-chair or/and TL serve as liaison for each TAG WG so the co-chair or/and TL can help resolve any concerns from the WG within the TAG’s own governance. This ensures TAG Leadership remains aware and conscious of the WG’s activities, deliverables, and overall health.
 
 ## Emeritus Chair
 

--- a/tags/resources/tag-formation-templates/template-roles.md
+++ b/tags/resources/tag-formation-templates/template-roles.md
@@ -1,23 +1,28 @@
 # Roles within the `<TAG NAME>`
 
+<!--- **How to complete this template.**  For each area, select the appropriate roles and responsibilities that align with your TAG's expected operation and adjust the language as necessary. Not all TAGs will need or use all roles, or leverage the time limits suggested, and each TAG may choose to redefine or adjust the scope of responsibilities and activities for a given role. The TOC reserves the right to define what TAG Chairs are responsible for, a sample of which have been provided here. --->
+
 The TAG includes several key roles that are critical to the group's success.
 Beyond the roles described in this document the TAG has many contributors, all serving in varying capacities.
 
 - [Roles within the `<TAG NAME>`](#roles-within-the-tag-name)
-  - [Chair](#chair)
+  - [Chairs](#chairs)
   - [Technical lead](#technical-lead)
   - [Working Group Lead](#working-group-lead)
   - [Project Lead](#project-lead)
   - [TOC liaison](#toc-liaison)
   - [Emeritus Chair](#emeritus-chair)
 
-## Chair
+## Chairs
 
-A Chair drives the CNCF community efforts of the TAGs domain.
-Chairs are experienced leaders within the CNCF community with rooted expertise in the TAG area. Chairs serve a two-year term but may renew their term by submitting a follow-up application.
+The TAG Chairs drive, guide, and coordinate the TAG's efforts within the broader CNCF ecosystem and within their TAG's community. They are supported by Technical Leads in the execution of TAG activities
+Chairs may be experienced leaders within the CNCF ecosystem and often have specialized domain expertise. Chairs have term limits, most commonly two years. Chairs continue to serve until removed either by an elected replacement or by the TOC.
+
 Chair applications go through an [election process](https://github.com/cncf/toc/blob/master/tags/cncf-tags.md#elections) with a final CNCF TOC vote.
+
 The [leadership election process is described here](template-leadership-election-process.md#chair).
 
+Chair responsibilities and expectations may include the following or delegation of the following: 
 * Manage the operations and governance of the group.
 * Organize, host, plan and facilitate TAG meetings and events.
 * Reporting to the CNCF TOC on the status of TAG work.
@@ -30,12 +35,15 @@ The [leadership election process is described here](template-leadership-election
 * Mentor community members in a leadership role within the TAG.
 * Enforce and promote diversity in TAG work.
 * Enforce and promote good communication in TAG efforts in accordance with the [CNCF CoC](https://www.cncf.io/conduct/)
+* Embody and promote excellent leadership in accordance with the [Technical Leadership principles](https://github.com/cncf/toc/blob/main/PRINCIPLES.md#technical-leadership-principles)
+
+For more information on TAG Chair responsibilities and expectations, please refer the to the TOC's description of [TAG Chairs](placeholder)
 
 ## Technical lead
 
 A technical lead (TL) expands the bandwidth of the leadership team in terms of covering technical areas, growing the community, organizing events or doing TAG communications.
 Proposals must have a TL or Chair working as an active sponsor.
-TLs are experienced contributors within the CNCF community with rooted expertise in the TAG area. TL serve a two-year term but may renew their term by submitting a follow-up application.
+TLs are experienced contributors within TAG, often recognized as successful past project leads, through their triage and planning, content and community management, or other attributes the Chairs determine to be valued for the TAG. TLs may be term limited akin to Chairs, the recommended time-frame is two years, but is dependent upon each TAG to define as their needs and activities warrant.
 Technical leads go through an [election process](https://github.com/cncf/toc/blob/master/tags/cncf-tags.md#elections) with a final CNCF TOC vote.
 The [leadership election process is described here](template-leadership-election-process.md#technical-lead).
 
@@ -50,14 +58,13 @@ The [leadership election process is described here](template-leadership-election
 * Enforce and encourage good communication in the TAG efforts following the [CNCF CoC](https://www.cncf.io/conduct/).
 * Support the TAG Chairs.
 
-## Working Group Lead
+## Working Group or Project Lead
 
-A working group lead is an experienced contributor to the TAG that applies to lead along one or two others a working group.
+Depending on the nature of the work being pursued by the TAG, the TAG Leadership may determine, with TOC liaison approval, that a particular project or effort warrants a working group. A working group or project lead(s) is an experienced contributor to the TAG that volunteers to lead a scoped activity and group alongside one or two others.  The number of leads may vary greatly depending on the defined scope and level of effort. Working Group or Project Leads are confirmed by the TAG Leadership and coordinate closely with the TAG Leadership sponsor for the group to keep them apprised of the group's progress and deliverables.
 Working groups as community governance structure are defined in the [CNCF TAG](https://github.com/cncf/toc/blob/master/tags) folder.
-TAG Chairs are responsible facilitating the working group applications and make sure that the process is done transparent, accessible and traceable for everyone.
-One of the TAG chairs serves as the working group sponsor and provides guidance to the working group leads.
-Working group leads are signed off by the TAG Chairs and the TOC Liaisons.
-The [leadership election process is described here](template-leadership-election-process.md#working-group-lead).
+TAG Leadership is responsible facilitating the working group applications and ensuring the group's work is done transparently, in a manner accessible and traceable for everyone.
+One of the TAG Leadership team (may be a Chair or TL) serves as the group sponsor and provides guidance to the group leads.
+Group leads are signed off by the TAG Chairs, the approval of the working group is given by TOC Liaisons. Should a group need to exist in perpetuity, the TAG Leadership is expected to provide term-limits or opportunities to rotate WG leadership as part of their governance.
 
 **A working group lead is expected to**:
 * Schedule, host, plan and facilitate meetings for the working group.
@@ -95,9 +102,11 @@ The TAG Chairs are responsible for establishing effective communication with the
 
 The TOC Liaison will occasionally prioritize TAG activities, as needed by the TOC, to further the [CNCF mission](https://github.com/cncf/foundation/blob/master/charter.md#1-mission-of-the-cloud-native-computing-foundation).
 
+For more information on TOC Liaisons, their responsibilities and expectations, please refer to the [TOC Liaisons section of CNCF Tags](https://github.com/cncf/toc/blob/main/tags/cncf-tags.md#toc-liaisons).
+
 ## Emeritus Chair
 
 After a TAG Chair completes their term, they transition into the role of Emeritus Chair.
 This role does not impose any obligations on the TAG, but it acknowledges their committed time and effort.
 The role also lets them share information about their previous work and contributions to the TAG.
-An Emeritus Chair retains the same rights/access as in their previous role.
+An Emeritus Chair does/does not retain the same rights/access as in their previous role.

--- a/tags/resources/tag-formation-templates/template-roles.md
+++ b/tags/resources/tag-formation-templates/template-roles.md
@@ -1,3 +1,103 @@
 # Roles within the `<TAG NAME>`
 
-*tbd* - contributions are welcome!
+The TAG includes several key roles that are critical to the group's success.
+Beyond the roles described in this document the TAG has many contributors, all serving in varying capacities.
+
+- [Roles within the `<TAG NAME>`](#roles-within-the-tag-name)
+  - [Chair](#chair)
+  - [Technical lead](#technical-lead)
+  - [Working Group Lead](#working-group-lead)
+  - [Project Lead](#project-lead)
+  - [TOC liaison](#toc-liaison)
+  - [Emeritus Chair](#emeritus-chair)
+
+## Chair
+
+A Chair drives the CNCF community efforts of the TAGs domain.
+Chairs are experienced leaders within the CNCF community with rooted expertise in the TAG area. Chairs serve a two-year term but may renew their term by submitting a follow-up application.
+Chair applications go through an [election process](https://github.com/cncf/toc/blob/master/tags/cncf-tags.md#elections) with a final CNCF TOC vote.
+The [leadership election process is described here](template-leadership-election-process.md#chair).
+
+* Manage the operations and governance of the group.
+* Organize, host, plan and facilitate TAG meetings and events.
+* Reporting to the CNCF TOC on the status of TAG work.
+* Encouraging community members to start projects and working groups.
+* Resolve technical difficulties and decisions related to multiple sub-projects.
+* Remind the community of the scope of the TAG and point out guardrails in discussions, working groups, and projects.
+* Serve as TAG leadership representative in CNCF project discussions and at community events.
+* Evolve the TAG to reflect ongoing changes in the industry.
+* Onboard and mentor new community members.
+* Mentor community members in a leadership role within the TAG.
+* Enforce and promote diversity in TAG work.
+* Enforce and promote good communication in TAG efforts in accordance with the [CNCF CoC](https://www.cncf.io/conduct/)
+
+## Technical lead
+
+A technical lead (TL) expands the bandwidth of the leadership team in terms of covering technical areas, growing the community, organizing events or doing TAG communications.
+Proposals must have a TL or Chair working as an active sponsor.
+TLs are experienced contributors within the CNCF community with rooted expertise in the TAG area. TL serve a two-year term but may renew their term by submitting a follow-up application.
+Technical leads go through an [election process](https://github.com/cncf/toc/blob/master/tags/cncf-tags.md#elections) with a final CNCF TOC vote.
+The [leadership election process is described here](template-leadership-election-process.md#technical-lead).
+
+**A technical lead is expected to**:
+* Establish and guide projects and working groups.
+* Resolve cross-sub-project technical difficulties and decisions.
+* Propose agenda items for meetings to ensure that open issues are discussed with the group when needed.
+* Serving as TAG leadership representative in CNCF project discussions and on community events.
+* Onboard and mentor new community members.
+* Mentor community members in a leadership role within the TAG.
+* Enforce and encourage diversity in the TAG efforts.
+* Enforce and encourage good communication in the TAG efforts following the [CNCF CoC](https://www.cncf.io/conduct/).
+* Support the TAG Chairs.
+
+## Working Group Lead
+
+A working group lead is an experienced contributor to the TAG that applies to lead along one or two others a working group.
+Working groups as community governance structure are defined in the [CNCF TAG](https://github.com/cncf/toc/blob/master/tags) folder.
+TAG Chairs are responsible facilitating the working group applications and make sure that the process is done transparent, accessible and traceable for everyone.
+One of the TAG chairs serves as the working group sponsor and provides guidance to the working group leads.
+Working group leads are signed off by the TAG Chairs and the TOC Liaisons.
+The [leadership election process is described here](template-leadership-election-process.md#working-group-lead).
+
+**A working group lead is expected to**:
+* Schedule, host, plan and facilitate meetings for the working group.
+* Provide technical direction unique to the working group.
+* Plan working group deliverables.
+* Report to the TAG on the working group status.
+* Evolve the working group.
+* Garner active participation.
+* Establish documents and correct permissions for contributions to occur.
+* Contribute content to the working group.
+* Onboard and setup the working group lead successor.
+
+## Project Lead
+
+A project lead manages a community group for a specified period of time and works to achieve a specific outcome that has been previously discussed and agreed upon.
+Unlike working groups, projects require a predetermined time frame and are limited in scope and focused on a central deliverable. The project proposal must be discussed at a meeting and actively communicated to the entire TAG community.
+A TAG Chair or TL acts as a sponsor of the project and dedicates a portion of their time to actively support the effort.
+TAG Chairs must sign off on the establishment of the project group.
+Due to the limited scope of the role, there are no specific requirements for structuring the selection process for the project lead.  
+The TAG Chairs are responsible for selecting a suitable project lead and must ensure that the establishment of the project is transparent, accessible, and understood by all.
+
+**A project lead is expected to**:
+* Schedule, host, plan and facilitate meetings for the project.
+* Provide technical direction unique to the project.
+* Plan the project deliverable.
+* Report to the TAG on the project status.
+* Garner active participation.
+* Establish documents and correct permissions for contributions to occur.
+* Contribute content to the project.
+
+## TOC liaison
+
+The [CNCF TAG](https://github.com/cncf/toc/blob/master/tags) process identifies a TOC Liaison.
+The TAG Chairs are responsible for establishing effective communication with the TOC liaison, including further communication to the wider TOC upon request.
+
+The TOC Liaison will occasionally prioritize TAG activities, as needed by the TOC, to further the [CNCF mission](https://github.com/cncf/foundation/blob/master/charter.md#1-mission-of-the-cloud-native-computing-foundation).
+
+## Emeritus Chair
+
+After a TAG Chair completes their term, they transition into the role of Emeritus Chair.
+This role does not impose any obligations on the TAG, but it acknowledges their committed time and effort.
+The role also lets them share information about their previous work and contributions to the TAG.
+An Emeritus Chair retains the same rights/access as in their previous role.


### PR DESCRIPTION
This PR adds a template under the `toc/tags/resources/tag-formation-template` to document the roles within TAGs. It also defines the structure of `template-leadership-election-process.md` file to enable adding references to it already. This PR adds content to the stub file structure that has been established with this [PR](https://github.com/cncf/toc/pull/1086). More PRs will follow to add content to the other template files.
The [original reference](https://github.com/cncf/tag-security/blob/main/governance/roles.md) of the roles file is sourced from the TAG Security. But I made a couple of edits.

The proposed template includes a definition for these roles:
* Chair
* Tech Lead
* Working Group Lead
* Project Lead
* TOC Liaison
* Emeritus Lead

I have reworked the sections and tried to reduce the overall size of the document, as the [TAG security role document](https://github.com/cncf/tag-security/blob/main/governance/roles.md) is quite large.

I removed a couple of roles that have been mentioned in the [TAG Security role doc](https://github.com/cncf/tag-security/blob/main/governance/roles.md):
* **Role of STAG representatives**: I think this role is not really a given for many TAGs. Usually, a Chair / TL does the comms to specific projects. For some, it might make sense at some point. Since this is a template that should also act as a getting started point, STAG representatives are not one of the core roles.
* **Team Leads**: Since the roles already mention projects and working groups (WG), team leads is just another variation which IMO complicates things. WG is a sub structure within the TAG to work on a continues effort (like doing security reviews), projects are short-term things like writing a White paper. Teams would be in the middle, continues projects that do not justify the structures of working groups. For some TAGs this might be useful, but as a baseline, I think this just adds governance clutter.
* **Group members**: AFAIK, member roles do not really exist in TAGs. Member roles do not come with any obligations to the TAG, and therefore do not really provide any value defining structures, making sure the member list is up-to-date …

**Facilitation roles**: I also removed this role. We want to acknowledge folks that invest time contributing to the TAG long term, being in this space of “facilitation” giving valuable input but do not have the capacity or the goal to step into one of the leadership roles. What do you all think about that? Should we include this role? I wonder if this is the same story as a “membership” role, which is not really desirable to establish (therefore I removed it for now…).

Would love to hear your thoughts.