### PR TITLE
Reference "how to start contributing" guide in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The CNCF provides a [list of services](https://www.cncf.io/services-for-projects
 
 Do you want to contribute to a project? We have a [guide](https://contribute.cncf.io/contributors/) to get you started.
 
-If you would like to know more about project lifecycle, we have [outlined the process](https://github.com/cncf/toc/blob/main/process/README.md). If you have any questions or don't know where to start, please open an [issue](https://github.com/cncf/toc/issues).
+If you would like to know more about the project lifecycle we use, we have [outlined the process](https://github.com/cncf/toc/blob/main/process/README.md). If you have any questions or don't know where to start, please open an [issue](https://github.com/cncf/toc/issues).
 
 ## Meeting Time
 


### PR DESCRIPTION
I think we should not point folks to the [project lifecycle process](https://github.com/cncf/toc/blob/main/process/README.md) if they want to start contributing to a project.

I changed that with a link to the contributor guide at https://contribute.cncf.io/contributors/