### PR TITLE
Updates related to TAG Security Leadership Changes

### DIFF
--- a/tags/README.md
+++ b/tags/README.md
@@ -32,9 +32,9 @@ a pull request with document referencing the roles and charter, updating the lis
 * [Alex Chircop](https://github.com/chira001)
 
 ### TAG Security 
-* [Brandon Lum](https://github.com/lumjjb)
 * [Aradhna Chetal](https://github.com/achetal01)
 * [Andrew Martin](https://github.com/sublimino)
+* [Pushkar Joglekar](https://github.com/pushkarj)
 
 ### TAG App-Delivery
 * [Alois Reitbauer](https://github.com/AloisReitbauer)
@@ -79,4 +79,5 @@ a pull request with document referencing the roles and charter, updating the lis
 | TAG Storage | [Erin Boyd](https://github.com/erinboyd) | 
 | TAG Security | [Emily Fox](https://github.com/TheFoxAtWork) |
 | TAG Contributor Strategy | [Paris Pittman](https://github.com/parispittman) |
-| TAG Contributor Strategy | [Stephen Augustus](https://github.com/justaugustus)
+| TAG Contributor Strategy | [Stephen Augustus](https://github.com/justaugustus) |
+| TAG Security | [Brandon Lum](https://github.com/lumjjb) |

--- a/tags/security.md
+++ b/tags/security.md
@@ -8,17 +8,16 @@ final review by Liz Rice, Joe Beda and Zhipeng Huang.
 
 ## **Operations**
 
-**TOC Liaisons:** [Justin Cormack](https://github.com/justincormack)
+**TOC Liaisons:** Duffie Cooley, Dave Zolotusky
 
-**TAG Chairs:** [Brandon Lum](https://github.com/lumjjb), [Aradhana Chetal](https://github.com/achetal01), [Andrew Martin](https://github.com/sublimino)
+**TAG Chairs:** [Aradhana Chetal](https://github.com/achetal01), [Andrew Martin](https://github.com/sublimino), [PushkarJ](https://github.com/pushkarj)
 
 **Tech Leads:** 
 * Justin Cappos ([@JustinCappos](https://github.com/JustinCappos)), New York University
 * Ash Narkar ([@ashutosh-narkar](https://github.com/ashutosh-narkar)), Styra
-* Andres Vega ([@anvega](https://github.com/anvega), VMware
-* Pushkar Joglekar ([@pushkarj](https://github.com/pushkarj), VMware
-* Ragashree Shekar ([@ragashreeshekar](https://github.com/ragashreeshekar)), TBD
-* Michael Lieberman ([@mlieberman85](https://github.com/mlieberman85)), TBD
+* Andres Vega ([@anvega](https://github.com/anvega)
+* Ragashree Shekar ([@ragashreeshekar](https://github.com/ragashreeshekar)), Independent
+* Michael Lieberman ([@mlieberman85](https://github.com/mlieberman85)), Kusari
 * Marina Moore ([@mnm678](https://github.com/mnm678)), NYU
 
 For complete details on process and elaboration of rules, see [TAG-Security governance](https://github.com/cncf/tag-security/tree/main/governance)


### PR DESCRIPTION
Reflects the current state from: https://github.com/cncf/tag-security#members