### PR TITLE
feat: update app-delivery chairs

### DIFF
--- a/tags/README.md
+++ b/tags/README.md
@@ -68,18 +68,18 @@ a pull request with document referencing the roles and charter, updating the lis
 
 ## Emeritus Chairs
 
-| TAG                                                               | Emeritus Chair                                           |
-|-------------------------------------------------------------------|----------------------------------------------------------|
-| TAG App Delivery                                                  | [Jennifer Strejevitch](https://github.com/Jenniferstrej) |
-| TAG App Delivery | [Hongchao Deng](https://github.com/hongchaodeng)         |
-| TAG App Delivery                                                  | [Bryan Liles](https://github.com/bryanl)                 |
-| TAG App Delivery                                                  | [Lei Zhang](https://github.com/resouer)                  |
-| TAG Contributor Strategy                                          | [Gerred Dillon](https://github.com/gerred)               |
-| TAG Security                                                      | [Sarah Allen](https://github.com/ultrasaurus)            |
-| TAG Security                                                      | [Jeyappragash Jeyakeerthi](https://github.com/pragashj)  |
-| TAG Security                                                      | [Dan Shaw](https://github.com/dshaw)                     |
-| TAG Storage                                                       | [Erin Boyd](https://github.com/erinboyd)                 | 
-| TAG Security                                                      | [Emily Fox](https://github.com/TheFoxAtWork)             |
-| TAG Contributor Strategy                                          | [Paris Pittman](https://github.com/parispittman)         |
-| TAG Contributor Strategy                                          | [Stephen Augustus](https://github.com/justaugustus)      |
-| TAG Security                                                      | [Brandon Lum](https://github.com/lumjjb)                 |
+| TAG                      | Emeritus Chair                                           |
+|--------------------------|----------------------------------------------------------|
+| TAG App Delivery         | [Jennifer Strejevitch](https://github.com/Jenniferstrej) |
+| TAG App Delivery         | [Hongchao Deng](https://github.com/hongchaodeng)         |
+| TAG App Delivery         | [Bryan Liles](https://github.com/bryanl)                 |
+| TAG App Delivery         | [Lei Zhang](https://github.com/resouer)                  |
+| TAG Contributor Strategy | [Gerred Dillon](https://github.com/gerred)               |
+| TAG Security             | [Sarah Allen](https://github.com/ultrasaurus)            |
+| TAG Security             | [Jeyappragash Jeyakeerthi](https://github.com/pragashj)  |
+| TAG Security             | [Dan Shaw](https://github.com/dshaw)                     |
+| TAG Storage              | [Erin Boyd](https://github.com/erinboyd)                 | 
+| TAG Security             | [Emily Fox](https://github.com/TheFoxAtWork)             |
+| TAG Contributor Strategy | [Paris Pittman](https://github.com/parispittman)         |
+| TAG Contributor Strategy | [Stephen Augustus](https://github.com/justaugustus)      |
+| TAG Security             | [Brandon Lum](https://github.com/lumjjb)                 |

--- a/tags/README.md
+++ b/tags/README.md
@@ -38,8 +38,8 @@ a pull request with document referencing the roles and charter, updating the lis
 
 ### TAG App-Delivery
 * [Alois Reitbauer](https://github.com/AloisReitbauer)
-* [Jennifer Strejevitch](https://github.com/Jenniferstrej)
-* [Hongchao Deng](https://github.com/hongchaodeng)
+* [Josh Gavant](https://github.com/joshgav)
+* [Thomas Schuetz](https://github.com/thschue)
 
 ### TAG Network 
 * [Lee Calcote](https://github.com/leecalcote)
@@ -68,16 +68,18 @@ a pull request with document referencing the roles and charter, updating the lis
 
 ## Emeritus Chairs
 
-| TAG | Emeritus Chair |
-|---|---|
-| TAG App Delivery | [Bryan Liles](https://github.com/bryanl) |
-| TAG App Delivery | [Lei Zhang](https://github.com/resouer) |
-| TAG Contributor Strategy | [Gerred Dillon](https://github.com/gerred) |
-| TAG Security | [Sarah Allen](https://github.com/ultrasaurus) |
-| TAG Security | [Jeyappragash Jeyakeerthi](https://github.com/pragashj) |
-| TAG Security | [Dan Shaw](https://github.com/dshaw) |
-| TAG Storage | [Erin Boyd](https://github.com/erinboyd) | 
-| TAG Security | [Emily Fox](https://github.com/TheFoxAtWork) |
-| TAG Contributor Strategy | [Paris Pittman](https://github.com/parispittman) |
-| TAG Contributor Strategy | [Stephen Augustus](https://github.com/justaugustus) |
-| TAG Security | [Brandon Lum](https://github.com/lumjjb) |
+| TAG                                                               | Emeritus Chair                                           |
+|-------------------------------------------------------------------|----------------------------------------------------------|
+| TAG App Delivery                                                  | [Jennifer Strejevitch](https://github.com/Jenniferstrej) |
+| TAG App Delivery | [Hongchao Deng](https://github.com/hongchaodeng)         |
+| TAG App Delivery                                                  | [Bryan Liles](https://github.com/bryanl)                 |
+| TAG App Delivery                                                  | [Lei Zhang](https://github.com/resouer)                  |
+| TAG Contributor Strategy                                          | [Gerred Dillon](https://github.com/gerred)               |
+| TAG Security                                                      | [Sarah Allen](https://github.com/ultrasaurus)            |
+| TAG Security                                                      | [Jeyappragash Jeyakeerthi](https://github.com/pragashj)  |
+| TAG Security                                                      | [Dan Shaw](https://github.com/dshaw)                     |
+| TAG Storage                                                       | [Erin Boyd](https://github.com/erinboyd)                 | 
+| TAG Security                                                      | [Emily Fox](https://github.com/TheFoxAtWork)             |
+| TAG Contributor Strategy                                          | [Paris Pittman](https://github.com/parispittman)         |
+| TAG Contributor Strategy                                          | [Stephen Augustus](https://github.com/justaugustus)      |
+| TAG Security                                                      | [Brandon Lum](https://github.com/lumjjb)                 |

--- a/tags/app-delivery.md
+++ b/tags/app-delivery.md
@@ -119,9 +119,9 @@ Lifecycle management of applications is a broad and mainstream topic of Cloud Na
 
 ## **Operations**
 
-* TOC Liaisons: Davanum Srinivas, Lei Zhang, Cathy Zhang
-* TAG chairs: [Alois Reitbauer](https://github.com/AloisReitbauer), [Jennifer Strejevitch](https://github.com/jenniferstrej), [Hongchao Deng](https://github.com/hongchaodeng)
-* Tech Leads: [Alex Jones](https://github.com/AlexsJones), [Thomas Schuetz](https://github.com/thschue), [Josh Gavant](https://github.com/joshgav)
+* TOC Liaisons: Katie Gamanji, Justin Cormack
+* TAG chairs: [Alois Reitbauer](https://github.com/AloisReitbauer), [Thomas Schuetz](https://github.com/thschue), [Josh Gavant](https://github.com/joshgav) 
+* Tech Leads: [Alex Jones](https://github.com/AlexsJones), [Lian Li](https://github.com/lianmakesthings) 
 * See [roles](https://github.com/cncf/tag-security/blob/main/governance/roles.md#role-of-chairs) for more information
 * Slack channel: #tag-app-delivery in CNCF workspace - [https://cloud-native.slack.com/messages/CL3SL0CP5](https://cloud-native.slack.com/messages/CL3SL0CP5) 
 


### PR DESCRIPTION
## This PR
* Updates the Chairs and TLs of the TAG App Delivery according to https://github.com/cncf/toc/issues/1151