### PR TITLE
working groups: add process for creating new WGs in a TAG

### DIFF
--- a/workinggroups/README.md
+++ b/workinggroups/README.md
@@ -1,10 +1,16 @@
 # CNCF Working Groups
 
-## Introduction
+## Working Groups (not in a TAG)
+
+This section outlines the process for working groups that are not part of a TAG.
+We are currently updating this process. To create a new working group today,
+please follow the process for creating a WG in a TAG.
+
+### Introduction
 
 The purpose of working groups are to study and report on a particular question and make recommendations based on its findings. The end result of a working group may be a new project proposal, landscape, whitepaper or even a report detailing their findings. The intention of working groups is not to host a full project or specification. Working Groups can be formed at any time but must be sponsored by a TOC member and voted with a super majority vote by the CNCF TOC. The TOC can also shut down a working group with a super majority vote.
 
-## Process
+### Process
 
 If you would like to submit a working group proposal, please submit a pull request to the working groups folder. As an example, you can see the other working group proposals here: https://github.com/cncf/toc/tree/main/workinggroups
 
@@ -18,3 +24,21 @@ At a minimum, please include this information:
 * The location of meetings / agenda / notes
 * Initial interested parties to show that there are multiple people across multiple orgs interested
 * The chair(s) and TOC sponsor being explicitly listed so they are discoverable
+
+## Working Groups (as part of a TAG)
+
+This section outlines the process for working groups
+that are part of a TAG.
+
+### Creating a new WG
+
+To request for a new working group as part of a TAG, an issue must be created
+against the `cncf/toc` repo stating the charter of the WG.
+
+The issue must be approved by:
+
+- TOC liaisons for the respective TAG.
+    - If a TAG has 3 TOC liaisons, the issue must be approved by at least 2 liaisons.
+- At least one of the TAG chairs/leads or any process spelled out in a TAG's charter.
+
+A publicly linkable written decision should be available for all approvals.


### PR DESCRIPTION
The whole working group process needs to be revamped as part of https://github.com/cncf/toc/issues/1158. There was some work that was started as part of https://github.com/cncf/toc/pull/868, but the PR has languished. 

This PR keeps the existing process and defines an additional lightweight process for creation of new WGs in a TAG. This mirrors the process we follow today.