### PR TITLE
first pass at stalebot config

### DIFF
--- a/.github/workflow/stalebot.yml
+++ b/.github/workflow/stalebot.yml
@@ -1,0 +1,17 @@
+name: 'Close stale issues and PRs'
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v8
+        with:
+          days-before-stale: 60
+          days-before-close: 14
+          stale-issue-message: 'This issue will be closed due to inactivity. If this is still a valid issue, please comment or label triage appropriately.'
+          stale-pr-message: 'This PR will be closed due to inactivity. If this is still a valid PR, please comment.'
+          only-pr-labels: 'wontfix'
+          exempt-issue-labels: 'project onboarding,enhancement'


### PR DESCRIPTION
This will stale-then-close any `wontfix` PR (we typically should leave PRs open in this repo)

This will stale-then-close any issue not labeled with `enhancement` or `project onboarding` (those seemed the two best exemptions)

Timing is: Mark stale after 60d, Auto-close 14d after