### PR TITLE
Add LFX Insights as an onboarding task for the CNCF in the issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/annual-review-template.md
+++ b/.github/ISSUE_TEMPLATE/annual-review-template.md
@@ -9,12 +9,12 @@ assignees: caniszczyk, amye
 
 Your annual review should answer the following questions:
 
-[] Include a link to your project’s devstats page. We will be looking for signs of consistent or increasing contribution activity. Please feel free to add commentary to add colour to the numbers and graphs we will see on devstats.
-[] How many maintainers do you have, and which organisations are they from? (Feel free to link to an existing MAINTAINERS file if appropriate.)
-[] What do you know about adoption, and how has this changed since your last review / since you joined Sandbox? If you can list companies that are end users of your project, please do so. (Feel free to link to an existing ADOPTERS file if appropriate.)
-[] How has the project performed against its goals since the last review? (We won't penalize you if your goals changed for good reasons.)
-[] What are the current goals of the project? For example, are you working on major new features? Or are you concentrating on adoption or documentation?
-[] How can the CNCF help you achieve your upcoming goals?
-[] Do you think that your project meets the criteria for [incubation](https://github.com/cncf/toc/blob/main/process/graduation_criteria.md#incubating-stage)?
+- [ ] Include a link to your project’s devstats page. We will be looking for signs of consistent or increasing contribution activity. Please feel free to add commentary to add colour to the numbers and graphs we will see on devstats.
+- [ ] How many maintainers do you have, and which organisations are they from? (Feel free to link to an existing MAINTAINERS file if appropriate.)
+- [ ] What do you know about adoption, and how has this changed since your last review / since you joined Sandbox? If you can list companies that are end users of your project, please do so. (Feel free to link to an existing ADOPTERS file if appropriate.)
+- [ ] How has the project performed against its goals since the last review? (We won't penalize you if your goals changed for good reasons.)
+- [ ] What are the current goals of the project? For example, are you working on major new features? Or are you concentrating on adoption or documentation?
+- [ ] How can the CNCF help you achieve your upcoming goals?
+- [ ] Do you think that your project meets the criteria for [incubation](https://github.com/cncf/toc/blob/main/process/graduation_criteria.md#incubating-stage)?
 
-After you've submitted a pull request, please add the pull request URL and date to your project in the [landscape](https://github.com/cncf/landscape/), this is how we track annual reviews! 
+After you've submitted a pull request, please add the pull request URL and date to your project in the [landscape](https://github.com/cncf/landscape/), this is how we track annual reviews!

--- a/.github/ISSUE_TEMPLATE/project-onboarding.md
+++ b/.github/ISSUE_TEMPLATE/project-onboarding.md
@@ -28,18 +28,19 @@ From the project side, please ensure that you:
 
 Things that CNCF will need from the project:
 
-- [ ] Provide emails for the maintainers added to <https://maintainers.cncf.io> in order to get access to the maintainers mailing list and ServiceDesk - project-onboarding@cncf.io is the best email to send those to
+- [ ] Provide emails for the maintainers added to <https://maintainers.cncf.io> in order to get access to the maintainers mailing list and ServiceDesk - <project-onboarding@cncf.io> is the best email to send those to
 - [ ] Trademarks: transfer any trademark and logo mark assets over to the LF - <https://github.com/cncf/foundation/tree/master/agreements> has agreements
-- [ ] GitHub: ensure 'thelinuxfoundation' and 'caniszczyk' are added as initial org owners, this helps us make sure we have continuity of GH ownership that we will onboard to our GitHub Enterprise instance: https://github.com/enterprises/cncf
+- [ ] GitHub: ensure 'thelinuxfoundation' and 'caniszczyk' are added as initial org owners, this helps us make sure we have continuity of GH ownership that we will onboard to our GitHub Enterprise instance: <https://github.com/enterprises/cncf>
 - [ ] GitHub: ensure [DCO](https://github.com/apps/dco) or [CLA](https://github.com/cncf/cla) are enabled for all GitHub repositories of the project
 - [ ] GitHub: ensure that that the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md) (or your adopted version of it) are explicitly referenced at the project's README on GitHub
 - [ ] Website: ensure LF footer is there and [website guidelines](https://github.com/cncf/foundation/blob/master/website-guidelines.md) followed (if your project doesn't have a dedicated website, please adopt those guidelines to the README file of your project on GitHub).
-- [ ] Website: Analytics transferred to projects@cncf.io
+- [ ] Website: Analytics transferred to <projects@cncf.io>
 - [ ] OpenSSF Best Practices Badge: Start on an OpenSSF Best Practices Badge <https://bestpractices.coreinfrastructure.org/en>
 
 Things that the CNCF will do or help the project to do:
 
 - [ ] Devstats: add to devstats <https://devstats.cncf.io/>
+- [ ] Insights: add to LFX Insights <https://insights.v3.lfx.linuxfoundation.org/>
 - [ ] Marketing: update relevant intro + slide decks
 - [ ] Events: update CFP + Registration + CFP Area forms
 - [ ] ServiceDesk: confirm maintainers have read <https://www.cncf.io/services-for-projects/>


### PR DESCRIPTION
As projects go through sandbox onboarding, we'd like to add them to Insights as well as devstats. This line should also be added to the existing issues that predate this change to the template. I can work with you on that @Cmierly.

Also, one commit in here fixes an issue with the Markdown for the Annual Report template. Other very minor fixes are from linting the Markdown before committing.