### PR TITLE
Add TAG leadership election governance template

### DIFF
--- a/tags/resources/tag-formation-templates/template-leadership-election-process.md
+++ b/tags/resources/tag-formation-templates/template-leadership-election-process.md
@@ -2,7 +2,7 @@
 
 <!--
 This file is a template which can be used by TAGs to bootstrap their governance structure.
-Please review this file carefully and make adjustments to better fit your TAGs structures where needed.
+Please review this file carefully and make adjustments to better fit your TAG where needed.
 -->
 
 The TAG leadership as well as the leadership of working groups or projects follows a common set of rules to ensure a transparent, open and accessible role transition between contributors.
@@ -11,15 +11,15 @@ Roles within the TAG outlining expectations and responsibilities are defined in 
 
 ## Process of nominations
 
-Leadership roles are open to all interested participants within the community. Depending on the needs of the community, as determined by the current TAG leadership team (Chairs and TL), nominations may come from working group co-chairs, TAG co-chairs and/or tech leads and/or other community members.
+Leadership roles are open to all interested participants within the community. Depending on the needs of the community, as determined by the current TAG leadership team (Chairs and TLs), nominations may come from working group co-chairs, TAG co-chairs and/or tech leads and/or other community members. Each TAG is expected to define this for themselves.
 
 The `<TAG NAME>` does not have a current limit on the amount of leadership roles. <!-- ! UPDATE IF DISCUSSED OTHERWISE ! -->
 
 Final nominations will adhere to the [CNCF's TOC described process](https://github.com/cncf/toc/blob/main/tags/cncf-tags.md#elections) as well as to the leadership nomination requirements described below.
 
-Any individual who is a member of the `<TAG NAME>` list or other official communication channels may nominate another individual.
+Any individual who is a member of the `<TAG NAME>`, its working groups, or otherwise considered an active participant of the group may nominate another individual. <!-- Update if your TAG has a more restricted pool of nominators -->
 
-The process of endorsing and selecting individuals will consider the following factors to ensure both the need for proper community representation and the necessary technical expertise:
+The process of endorsing and selecting individuals will consider the following factors to ensure both the need for proper community representation and the necessary technical expertise: <!-- If the TAG has any additional items, such as leading a minimum number of projects, or facilitating a number meetings, they should be added to this list under "Body of work" -->
 
 * Gender diversity
 * Company diversity
@@ -42,11 +42,12 @@ Upon close of nominations, a decision should be made within the next month.
 
 ### Submitting a nomination
 
-Nominations are to be submitted to [TAG Co-Chair's email alias](mailto:cncf-tag-chairs@lists.cncf.io) with the details: <!-- ! UPDATE EMAIL ! -->
+Nominations are to be submitted to [TAG Co-Chair's email alias](mailto:cncf-tag-chairs@lists.cncf.io) with the details: <!-- ! UPDATE EMAIL with the TAG's Leadership's correct mailing list ! -->
 
 * Subject "NOMINATION $(TAG Chair, TAG TL, WG XYZ Chair): $NAME-OF-NOMINEE"
 * CC the nominee
 * Justification
+* Nominee Biography
 
 ## Nomination requirements
 
@@ -80,3 +81,7 @@ To ensure nominations are thoughtful and supported, in addition to the above req
 ## Announcing nomination results
 
 The TAG leadership will release aggregate information about the nominees at the end of the nomination process. Aggregate information will not include who nominated someone.
+
+## Next Steps
+
+If the role under nomination requires TOC approval or vote, the TAG Co-chairs are responsible for coordinating and executing that in accordance with the TOC's processes (defined previously).

--- a/tags/resources/tag-formation-templates/template-leadership-election-process.md
+++ b/tags/resources/tag-formation-templates/template-leadership-election-process.md
@@ -84,7 +84,6 @@ If a given nominee does not meet all the requirements, the TAG leadership will s
 
 **Nominations must**:
 
-* Come from someone other than the nominee
 * Have justification from the nominator regarding the nominee's capabilities
 
 ### Justification for nominees

--- a/tags/resources/tag-formation-templates/template-leadership-election-process.md
+++ b/tags/resources/tag-formation-templates/template-leadership-election-process.md
@@ -36,7 +36,7 @@ In case there are no individuals expressing interest in taking up leadership pos
 
 * **TAG Chair**:
   * Start: CNCF staff initiates election 1-2 months after the TOC election.
-  * ominations: Open for 1-2 months. Co-chairs or TOC members can nominate.
+  * nominations: Open for 1-2 months. Co-chairs or TOC members can nominate.
   * Vote: TOC votes.
 * **TAG TL**:
   * Start: TAG co-chairs initiate election after the end of the current term.

--- a/tags/resources/tag-formation-templates/template-leadership-election-process.md
+++ b/tags/resources/tag-formation-templates/template-leadership-election-process.md
@@ -1,3 +1,82 @@
 # Leadership election process within the `<TAG NAME>`
 
-*tbd* - contributions are welcome!
+<!--
+This file is a template which can be used by TAGs to bootstrap their governance structure.
+Please review this file carefully and make adjustments to better fit your TAGs structures where needed.
+-->
+
+The TAG leadership as well as the leadership of working groups or projects follows a common set of rules to ensure a transparent, open and accessible role transition between contributors.
+Contributors in leadership positions provide guidance and directions to TAG members and ensure that the efforts are in line with its mission and values, as well as the goals of the TAG.
+Roles within the TAG outlining expectations and responsibilities are defined in the [roles](template-roles.md) governance document. <!-- ! UPDATE THE LINK ! -->
+
+## Process of nominations
+
+Leadership roles are open to all interested participants within the community. Depending on the needs of the community, as determined by the current TAG leadership team (Chairs and TL), nominations may come from working group co-chairs, TAG co-chairs and/or tech leads and/or other community members.
+
+The `<TAG NAME>` does not have a current limit on the amount of leadership roles. <!-- ! UPDATE IF DISCUSSED OTHERWISE ! -->
+
+Final nominations will adhere to the [CNCF's TOC described process](https://github.com/cncf/toc/blob/main/tags/cncf-tags.md#elections) as well as to the leadership nomination requirements described below.
+
+Any individual who is a member of the `<TAG NAME>` list or other official communication channels may nominate another individual.
+
+The process of endorsing and selecting individuals will consider the following factors to ensure both the need for proper community representation and the necessary technical expertise:
+
+* Gender diversity
+* Company diversity
+* Geo diversity
+* Number of nominations from different companies, people, regions for a single individual
+* Existing body of work
+* Justification provided during nomination
+
+In case there are no individuals expressing interest in taking up leadership positions, an evaluation process for the TAG / working group or project archival may be initiated, as [outlined by the TOC](https://github.com/cncf/toc/blob/main/tags/cncf-tags.md#retirement).
+
+### Community timeline
+
+Community nominations will run for at least 1 month, with a maximum up to 2 months.
+
+* For TAG Chair nominations, the TOC will take a vote as [described by the TOC](https://github.com/cncf/toc/blob/main/tags/cncf-tags.md#elections).
+* For TAG TL, TAG Chairs will vote and propose the nomination to the TOC. The TOC takes the final vote.
+* For Working Group and Project Chairs, the TAG Chairs and Leads will take a vote.
+
+Upon close of nominations, a decision should be made within the next month.
+
+### Submitting a nomination
+
+Nominations are to be submitted to [TAG Co-Chair's email alias](mailto:cncf-tag-chairs@lists.cncf.io) with the details: <!-- ! UPDATE EMAIL ! -->
+
+* Subject "NOMINATION $(TAG Chair, TAG TL, WG XYZ Chair): $NAME-OF-NOMINEE"
+* CC the nominee
+* Justification
+
+## Nomination requirements
+
+The `<TAG NAME>` recognizes and values the achievements of individuals who have proven themselves in this community.
+If a given nominee does not meet all the requirements, the TAG leadership will still review the nomination and justification to determine if enough intent and commitment is present to move forward with an endorsement.
+
+**Nominees must**:
+
+* Be the author of at least one pull request against the `<TAG NAME>` repository
+* Be active in the community within the last 3 months before their nomination
+  * Active - Attending at least 1 `<TAG NAME>` Regular Meeting a month
+  * Engaging in community chat via Slack or lists
+  * Commenting on PRs and issues to drive suggestions to proposals, define scope, resolve clarity issues, etc.
+* Agree to the nomination
+
+*additional requirements may be defined in the specific [roles](template-roles.md) governance document* <!-- ! UPDATE THE LINK ! -->
+
+**Nominations must**:
+
+* Come from someone other than the nominee
+* Have justification from the nominator regarding the nominee's capabilities
+
+### Justification for nominees
+
+To ensure nominations are thoughtful and supported, in addition to the above requirements, a justification must enumerate on the nominee's:
+
+* TAG Community involvement
+* Leadership and collaboration skills
+* Willingness to learn and expand existing technical knowledge
+
+## Announcing nomination results
+
+The TAG leadership will release aggregate information about the nominees at the end of the nomination process. Aggregate information will not include who nominated someone.

--- a/tags/resources/tag-formation-templates/template-leadership-election-process.md
+++ b/tags/resources/tag-formation-templates/template-leadership-election-process.md
@@ -36,7 +36,7 @@ In case there are no individuals expressing interest in taking up leadership pos
 
 * **TAG Chair**:
   * Start: CNCF staff initiates election 1-2 months after the TOC election.
-  * nominations: Open for 1-2 months. Co-chairs or TOC members can nominate.
+  * Nominations: Open for 1-2 months. Co-chairs or TOC members can nominate.
   * Vote: TOC votes.
 * **TAG TL**:
   * Start: TAG co-chairs initiate election after the end of the current term.

--- a/tags/resources/tag-formation-templates/template-leadership-election-process.md
+++ b/tags/resources/tag-formation-templates/template-leadership-election-process.md
@@ -17,7 +17,7 @@ Elections should be conducted by CNCF staff. TAG leadership Election should star
 
 For the immediate election in 2025, roughly 50% of the roles should be made available for election where existing leaders can choose to rerun, starting with the longest serving leaders. The rest of the leads who are not up for election should plan to be up for elections in 2026.
 
-co-chairs can be nominated by any existing co-chairs or TOC member. TL roles should be nominated by any existing co-chairs or TLs. WG leads can be nominated by any TAG leaders. TAGs may define their own process by which they field nominations for these roles, provided they adhere to CNCF and TOC expectations of openness, transparency, and accountability.
+Co-chairs can be nominated by any existing co-chairs or TOC member. TL roles should be nominated by any existing co-chairs or TLs. WG leads can be nominated by any TAG leaders. TAGs may define their own process by which they field nominations for these roles, provided they adhere to CNCF and TOC expectations of openness, transparency, and accountability.
 
 Co-chair elections should be voted on by the TOC. Other TAG leads elections should be voted by TAG co-chairs, TLs, WG leads or other active contributors of the TAG.
 

--- a/tags/resources/tag-formation-templates/template-leadership-election-process.md
+++ b/tags/resources/tag-formation-templates/template-leadership-election-process.md
@@ -11,13 +11,15 @@ Roles within the TAG outlining expectations and responsibilities are defined in 
 
 ## Process of nominations
 
-Leadership roles are open to all interested participants within the community. Depending on the needs of the community, as determined by the current TAG leadership team (Chairs and TLs), nominations may come from working group co-chairs, TAG co-chairs and/or tech leads and/or other community members. Each TAG is expected to define this for themselves.
+Leadership roles are open to all interested participants within the community. Depending on the needs of the community, as determined by the current TAG leadership team (Chairs and TLs), nominations may come from working group co-chairs, TAG co-chairs and/or tech leads and/or other community members. Each leadership role is on a 2 year term once appointed.
 
-The `<TAG NAME>` does not have a current limit on the amount of leadership roles. <!-- ! UPDATE IF DISCUSSED OTHERWISE ! -->
+Elections should be conducted by CNCF staff. TAG leadership Election should start 1-2 months after the TOC election finishes each year, pending CNCF staff’s availability to run the elections.
 
-Final nominations will adhere to the [CNCF's TOC described process](https://github.com/cncf/toc/blob/main/tags/cncf-tags.md#elections) as well as to the leadership nomination requirements described below.
+For the immediate election in 2025, roughly 50% of the roles should be made available for election where existing leaders can choose to rerun, starting with the longest serving leaders. The rest of the leads who are not up for election should plan to be up for elections in 2026.
 
-Any individual who is a member of the `<TAG NAME>`, its working groups, or otherwise considered an active participant of the group may nominate another individual. <!-- Update if your TAG has a more restricted pool of nominators -->
+co-chairs can be nominated by any existing co-chairs or TOC member. TL roles should be nominated by any existing co-chairs or TLs. WG leads can be nominated by any TAG leaders. TAGs may define their own process by which they field nominations for these roles, provided they adhere to CNCF and TOC expectations of openness, transparency, and accountability.
+
+Co-chair elections should be voted on by the TOC. Other TAG leads elections should be voted by TAG co-chairs, TLs, WG leads or other active contributors of the TAG.
 
 The process of endorsing and selecting individuals will consider the following factors to ensure both the need for proper community representation and the necessary technical expertise: <!-- If the TAG has any additional items, such as leading a minimum number of projects, or facilitating a number meetings, they should be added to this list under "Body of work" -->
 
@@ -30,15 +32,25 @@ The process of endorsing and selecting individuals will consider the following f
 
 In case there are no individuals expressing interest in taking up leadership positions, an evaluation process for the TAG / working group or project archival may be initiated, as [outlined by the TOC](https://github.com/cncf/toc/blob/main/tags/cncf-tags.md#retirement).
 
-### Community timeline
+### Leadership election timeline
 
-Community nominations will run for at least 1 month, with a maximum up to 2 months.
+* **TAG Chair**:
+  * Start: CNCF staff initiates election 1-2 months after the TOC election.
+  * ominations: Open for 1-2 months. Co-chairs or TOC members can nominate.
+  * Vote: TOC votes.
+* **TAG TL**:
+  * Start: TAG co-chairs initiate election after the end of the current term.
+  * Nominations: Open for 1-2 months. Co-chairs or TLs can nominate.
+  * Vote: TAG co-chairs, TLs, WG leads, or other active members of the TAG vote.
+* **Working Group Chairs and Leads (WG Chairs, WG TLs)**:
+  * Start: TAG co-chairs initiate election after the end of the current term.
+  * Nominations: Open for 1-2 months. TAG co-chairs, TLs, WG leads or other active contributors to the TAG can nominate.
+  * Vote: TAG co-chairs, TLs, WG leads, or other active members of the TAG vote.
 
-* For TAG Chair nominations, the TOC will take a vote as [described by the TOC](https://github.com/cncf/toc/blob/main/tags/cncf-tags.md#elections).
-* For TAG TL, TAG Chairs will vote and propose the nomination to the TOC. The TOC takes the final vote.
-* For Working Group and Project Chairs, the TAG Chairs and Leads will take a vote.
-
-Upon close of nominations, a decision should be made within the next month.
+* **Subsequent Steps for Any Role**:
+  * Announcement: Communicate the result of the election to the community.
+  * Update Resources: Update TAG meeting notes, README files, websites, [repository access](https://github.com/cncf/people/blob/main/config.yaml), and reach out to CNCF staff to share email, Google Drive, and YouTube access if needed.
+  * Emeritus: Add the outgoing community leader to the emeritus list and update documents and resources accordingly.
 
 ### Submitting a nomination
 
@@ -48,6 +60,11 @@ Nominations are to be submitted to [TAG Co-Chair's email alias](mailto:cncf-tag-
 * CC the nominee
 * Justification
 * Nominee Biography
+
+### Vacancies
+
+In the event that a TAG lead vacates their seat during their term, a by-election shall be conducted to fill the position for the remainder of the term in accordance with the regular election procedure.
+The TAG co-chairs may initiate a vote of no confidence in a TAG leader when the TAG leader has not performed any TAG leader tasks for 6 months. The leader shall be removed if the motion is approved by at least sixty percent (60%) of the TAG leaders along with the approval support from all of the TOC Liaisons for the TAG.
 
 ## Nomination requirements
 
@@ -77,11 +94,3 @@ To ensure nominations are thoughtful and supported, in addition to the above req
 * TAG Community involvement
 * Leadership and collaboration skills
 * Willingness to learn and expand existing technical knowledge
-
-## Announcing nomination results
-
-The TAG leadership will release aggregate information about the nominees at the end of the nomination process. Aggregate information will not include who nominated someone.
-
-## Next Steps
-
-If the role under nomination requires TOC approval or vote, the TAG Co-chairs are responsible for coordinating and executing that in accordance with the TOC's processes (defined previously).


### PR DESCRIPTION
This PR adds a template under the `toc/tags/resources/tag-formation-template` to document the leadership election process within TAGs. This PR https://github.com/cncf/toc/pull/1086 established the `/tags/resources` structure, and this PR adds content to one of the empty stub files. More PRs will follow to add content to the other template files (like: https://github.com/cncf/toc/pull/1128 and https://github.com/cncf/toc/pull/1116).

The election process is a combined version of the [TAG ENV TL](https://github.com/cncf/tag-env-sustainability/blob/main/governance/tech-lead-proposal-process.md), [TAG ENV Chair](https://github.com/cncf/tag-env-sustainability/blob/main/governance/chair-proposal-process.md) and [TAG ENV WG Chair](https://github.com/cncf/tag-env-sustainability/blob/main/governance/working-group-chair-proposal-process.md) election process. TAG ENV originally pulled the governance files from TAG Security, see [file](https://github.com/cncf/tag-security/blob/main/governance/tech-lead-proposal-process.md).