### PR TITLE
Add TAG Environmental Sustainability Tech Lead to keep this doc in sync

### DIFF
--- a/tags/cncf-tags.md
+++ b/tags/cncf-tags.md
@@ -53,6 +53,7 @@ TOC and TOC Contributors have fulfilled TAG duties in the past and will continue
 
 #### Tech Leads
 * [Cara Delia](https://github.com/caradelia)
+* [Kristina Devochko](https://github.com/guidemetothemoon)
 
 ### TAG Network
 #### Chairs


### PR DESCRIPTION
Updating this while we are working out the process of keeping things in sync across repos
Linked to: https://github.com/cncf/tag-env-sustainability/pull/320