### PR TITLE
Update sandbox onboarding template.

### DIFF
--- a/.github/ISSUE_TEMPLATE/project-onboarding.md
+++ b/.github/ISSUE_TEMPLATE/project-onboarding.md
@@ -1,5 +1,5 @@
 ---
-name: Project onboarding - Sandbox projects
+name: Project onboarding for Sandbox projects
 about: Create a checklist of tasks for a project to complete the onboarding process
 title: "[SANDBOX PROJECT ONBOARDING] project"
 labels: project onboarding, sandbox
@@ -7,44 +7,46 @@ assignees: caniszczyk, amye, idvoretskyi, jeefy, krook, Cmierly
 ---
 
 Welcome to CNCF Project Onboarding!
-This is an issue created to help onboard your project into the CNCF after the TOC has voted to accept your project.
+
+This is an issue created to help onboard your project into the CNCF after the TOC has voted to accept your project into the Sandbox.
+
 We would like to complete onboarding within one month of acceptance.
 
-From the project side, please ensure that you:
+**From the project side, please ensure that:**
 
-- [ ] Understand the project proposal process and requirements: <https://github.com/cncf/toc/blob/main/process/project_proposals.md#introduction>
-- [ ] Understand the services available for your project at CNCF <https://www.cncf.io/services-for-projects/>
-- [ ] Ensure your project meets the CNCF IP Policy: <https://github.com/cncf/foundation/blob/master/charter.md#11-ip-policy>
-- [ ] Review the online programs guidelines: <https://github.com/cncf/foundation/blob/master/online-programs-guidelines.md>
-- [ ] Understand the trademark guidelines: <https://www.linuxfoundation.org/en/trademark-usage/>
-- [ ] Understand the license allowlist: <https://github.com/cncf/foundation/blob/master/allowed-third-party-license-policy.md#approved-licenses-for-allowlist>
-- [ ] Is your project working on written, open governance? see <https://contribute.cncf.io/maintainers/governance/>
-- [ ] Slack: Are your Slack channels migrated to the Kubernetes or CNCF Slack workspace? (see <https://slack.com/help/articles/217872578-Import-data-from-one-Slack-workspace-to-another> for more details)
-- [ ] Is your project in its own separate neutral GitHub organization? This will make it transferable to the CNCF's GitHub Enterprise account.
-- [ ] Submitted a pull request to add your project as a sandbox project to <https://landscape.cncf.io>
-- [ ] Create maintainer list + add to aggregated <https://maintainers.cncf.io> list by submitting a PR to it
-- [ ] Artwork: Submit a pull request to <https://github.com/cncf/artwork> with your artwork
-- [ ] Domain: transfer domain to the CNCF - <https://jira.linuxfoundation.org/plugins/servlet/theme/portal/2/create/63>
+- [ ] You understand the project proposal process and requirements: <https://github.com/cncf/toc/blob/main/process/project_proposals.md#introduction>
+- [ ] You understand the services available for your project at CNCF <https://www.cncf.io/services-for-projects/>
+- [ ] You ensure your project meets the CNCF IP Policy: <https://github.com/cncf/foundation/blob/master/charter.md#11-ip-policy>
+- [ ] You review the online programs guidelines: <https://github.com/cncf/foundation/blob/master/online-programs-guidelines.md>
+- [ ] You understand the trademark guidelines: <https://www.linuxfoundation.org/en/trademark-usage/>
+- [ ] You understand the license allowlist: <https://github.com/cncf/foundation/blob/master/allowed-third-party-license-policy.md#approved-licenses-for-allowlist>
+- [ ] Your project is working on written, open governance. See <https://contribute.cncf.io/maintainers/governance/>
+- [ ] Your Slack channels are migrated to the Kubernetes or CNCF Slack workspace. See <https://slack.com/help/articles/217872578-Import-data-from-one-Slack-workspace-to-another> for more details)
+- [ ] Your project in its own separate neutral GitHub organization. This will make it transferable to the CNCF's GitHub Enterprise account.
+- [ ] You submit a pull request to add your project as a Sandbox project to <https://landscape.cncf.io>
+- [ ] You create maintainer list + add to aggregated <https://maintainers.cncf.io> list by submitting a PR to it
+- [ ] You submit a pull request to <https://github.com/cncf/artwork> with your artwork
+- [ ] You transfer your domain to the CNCF - <https://jira.linuxfoundation.org/plugins/servlet/theme/portal/2/create/63>
 
-Things that CNCF will need from the project:
+**Things that CNCF will need from the project:**
 
 - [ ] Provide emails for the maintainers added to <https://maintainers.cncf.io> in order to get access to the maintainers mailing list and Service Desk - <project-onboarding@cncf.io> is the best email to send those to
-- [ ] Trademarks: transfer any trademark and logo assets over to the LF - <https://github.com/cncf/foundation/tree/master/agreements> has agreements
-- [ ] GitHub: ensure `thelinuxfoundation`, `caniszczyk`, and `krook` are added as initial org owners, this helps us make sure we have continuity of GH ownership as we onboard your project to our GitHub Enterprise instance: <https://github.com/enterprises/cncf>
-- [ ] GitHub: ensure [DCO](https://github.com/apps/dco) or [CLA](https://github.com/cncf/cla) are enabled for all GitHub repositories of the project
-- [ ] GitHub: ensure that that the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md) (or your adopted version of it) are explicitly referenced at the project's README on GitHub
-- [ ] Website: ensure LF footer is there and [website guidelines](https://github.com/cncf/foundation/blob/master/website-guidelines.md) followed (if your project doesn't have a dedicated website, please adopt those guidelines to the README file of your project on GitHub).
-- [ ] Website: Analytics transferred to <projects@cncf.io>
-- [ ] OpenSSF Best Practices Badge: Start on an OpenSSF Best Practices Badge <https://bestpractices.coreinfrastructure.org/en>
+- [ ] Transfer any trademark and logo assets over to the LF - <https://github.com/cncf/foundation/tree/master/agreements> has agreements
+- [ ] Accept the invite to join the CNCF GitHub Enterprise account. We'll then add `thelinuxfoundation` as an organization owner to ensure neutral hosting of your project
+- [ ] Ensure that [DCO](https://github.com/apps/dco) or [CLA](https://github.com/cncf/cla) are enabled for all GitHub repositories of the project
+- [ ] Ensure that that the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md) (or your adopted version of it) are explicitly referenced at the project's README on GitHub
+- [ ] Ensure LF footer is on your website and [guidelines](https://github.com/cncf/foundation/blob/master/website-guidelines.md) followed (if your project doesn't have a dedicated website, please adopt those guidelines for the README file of your project on GitHub).
+- [ ] Transfer website analytics to <projects@cncf.io>
+- [ ] Start on an OpenSSF Best Practices Badge <https://bestpractices.coreinfrastructure.org/en>
 
-Things that the CNCF will do or help the project to do:
+**Things that the CNCF will do or help the project to do:**
 
-- [ ] DevStats: add to DevStats <https://devstats.cncf.io/>
-- [ ] Insights: add to LFX Insights <https://insights.v3.lfx.linuxfoundation.org/>. This is an app added to the GitHub organization.
-- [ ] Marketing: update relevant intro + slide decks
-- [ ] Events: update CFP + Registration + CFP Area forms
-- [ ] Service Desk: confirm maintainers have read <https://www.cncf.io/services-for-projects/>
-- [ ] CNCF welcome email sent to confirm maintainer list access
-- [ ] Book time with the team with <http://project-meetings.cncf.io>
+- [ ] Add your project to DevStats <https://devstats.cncf.io/>
+- [ ] Add your project to LFX Insights <https://insights.v3.lfx.linuxfoundation.org/>. This is a read-only app added to the GitHub organization once your project is in the CNCF GitHub Enterprise account and we add `thelinuxfoundation` as an organization owner.
+- [ ] Update relevant marketing intros and slide decks
+- [ ] Update event call for papers, registration, and CFP area forms
+- [ ] Confirm maintainers have read about what's available through the Service Desk <https://www.cncf.io/services-for-projects/>
+- [ ] CNCF sends a welcome email to confirm maintainer list access
+- [ ] Book time with the team using <http://project-meetings.cncf.io>
 - [ ] Create space for meetings/events on <https://community.cncf.io>, e.g., <https://community.cncf.io/pravega-community/> - (<https://github.com/cncf/communitygroups/blob/main/README.md#cncf-projects>)
 - [ ] Adopt a license scanning tool, like [FOSSA](https://fossa.com/) or [Snyk](https://snyk.io/)


### PR DESCRIPTION
* Fixed grammar and consistency in onboarding items
* Clarify GHE onboarding and `thelinuxfoundation` needs to be an organization owner
* Add more detail that onboarding Insights adds a read-only app 