### PR TITLE
Update sandbox links

### DIFF
--- a/process/graduation_criteria.md
+++ b/process/graduation_criteria.md
@@ -10,7 +10,7 @@ Incubating and graduated projects have access to all resources listed at [cncf.i
 
 To be accepted in the sandbox a project must
 
-* Apply to join the sandbox using the [form](https://github.com/cncf/sandbox/issues/new?assignees=&labels=New&projects=&template=application.yml&title=%5BSandbox%5D+%3CProject+Name%3E/choose)
+* Apply to join the sandbox using the [form](https://github.com/cncf/sandbox/issues/new?assignees=&labels=New&projects=&template=application.yml&title=%5BSandbox%5D+%3CProject+Name%3E)
 * Adopt the CNCF [Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md)
 * Adhere to CNCF [IP Policy](https://github.com/cncf/foundation/blob/master/charter.md#11-ip-policy) (including trademark transferred)
 * List their sandbox status prominently on website/readme

--- a/process/graduation_criteria.md
+++ b/process/graduation_criteria.md
@@ -10,7 +10,7 @@ Incubating and graduated projects have access to all resources listed at [cncf.i
 
 To be accepted in the sandbox a project must
 
-* Apply to join the sandbox using the [form](https://github.com/cncf/sandbox/issues/new/choose)
+* Apply to join the sandbox using the [form](https://github.com/cncf/sandbox/issues/new?assignees=&labels=New&projects=&template=application.yml&title=%5BSandbox%5D+%3CProject+Name%3E/choose)
 * Adopt the CNCF [Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md)
 * Adhere to CNCF [IP Policy](https://github.com/cncf/foundation/blob/master/charter.md#11-ip-policy) (including trademark transferred)
 * List their sandbox status prominently on website/readme

--- a/process/project_proposals.md
+++ b/process/project_proposals.md
@@ -75,7 +75,7 @@ All exceptions and "declined" or "postponed" outcomes are handled by the TOC. Pr
 ![Sandbox process](sandbox-application-process-2022.png)
 
 #### Applying for Sandbox
-   * Projects apply for sandbox through the Sandbox Repo's *[Issue Form](https://github.com/cncf/sandbox/issues/new)*. More information on this process is found on the main [Sandbox repo page](https://github.com/cncf/sandbox).
+   * Projects apply for sandbox through the Sandbox Repo's *[Issue Form](https://github.com/cncf/sandbox/issues/new?assignees=&labels=New&projects=&template=application.yml&title=%5BSandbox%5D+%3CProject+Name%3E)*. More information on this process is found on the main [Sandbox repo page](https://github.com/cncf/sandbox).
 
 #### Annual Review of Sandbox projects
 

--- a/process/sandbox.md
+++ b/process/sandbox.md
@@ -1,5 +1,6 @@
-# CNCF Sandbox Overview 
-![CNCF Sandbox](https://github.com/cncf/artwork/blob/master/other/cncf-sandbox/horizontal/color/cncf-sandbox-horizontal-color.png)
+# CNCF Sandbox Overview
+
+![CNCF Sandbox](https://raw.githubusercontent.com/cncf/artwork/main/other/cncf-sandbox/horizontal/color/cncf-sandbox-horizontal-color.png)
 
 The CNCF Sandbox is the entry point for early stage projects and has four goals:
 
@@ -83,9 +84,9 @@ Some key points:
 * Reviewed on an annual basis; submit a report to the TOC for review
 * CNCF Sandbox projects can stay in the sandbox indefinitely
 
-### Application into Sandbox 
+### Application into Sandbox
 
-Projects apply through the Sandbox Repo's *[Issue Form](https://github.com/cncf/sandbox/issues/new)*. More information on this process is found on the main [Sandbox repo page](https://github.com/cncf/sandbox).
+Projects apply through the Sandbox Repo's *[Issue Form](https://github.com/cncf/sandbox/issues/new?assignees=&labels=New&projects=&template=application.yml&title=%5BSandbox%5D+%3CProject+Name%3E)*. More information on this process is found on the main [Sandbox repo page](https://github.com/cncf/sandbox).
 Frequency of reviews can be found on the [repo's README under "Frequency"](https://github.com/cncf/sandbox/blob/main/README.md#Frequency).
 
 ### Project onboarding


### PR DESCRIPTION
We have an issue form that is for Sandbox applications but we were not linking directly to it. Instead, the links pointed to the issue selection page. I also fixed the broken Sandbox image link.