### PR TITLE
Make release expectations clear for graduated projects

### DIFF
--- a/.github/ISSUE_TEMPLATE/template-graduation-application.md
+++ b/.github/ISSUE_TEMPLATE/template-graduation-application.md
@@ -194,7 +194,7 @@ Note: this section may be augmented by the completion of a Governance Review fro
   - [ ] information on branch and tag strategies
   - [ ] branch and platform support and length of support
   - [ ] artifacts included in the release.
-  - [ ] Additional information on topics such as LTS and edge releases are optional. Release expectations are a social contract between the project and its end users and hence changes to these should be well thought out, discussed, socialized and as necessary agreed upon by project leadership before getting rolled out.
+  - Additional information on topics such as LTS and edge releases are optional. Release expectations are a social contract between the project and its end users and hence changes to these should be well thought out, discussed, socialized and as necessary agreed upon by project leadership before getting rolled out.
 
 <!-- (Project assertion goes here) --> 
 

--- a/.github/ISSUE_TEMPLATE/template-graduation-application.md
+++ b/.github/ISSUE_TEMPLATE/template-graduation-application.md
@@ -189,11 +189,11 @@ Note: this section may be augmented by the completion of a Governance Review fro
 
 - [ ] **Document the project's release process and guidelines publicly in a RELEASES.md or equivalent file that defines:** 
 
-  - [ ] release expectations (scheduled or based on feature implementation)
-  - [ ] tagging as stable, unstable, and security related releases
-  - [ ] information on branch and tag strategies
-  - [ ] branch and platform support and length of support
-  - [ ] artifacts included in the release.
+  - [ ] Release expectations (scheduled or based on feature implementation)
+  - [ ] Tagging as stable, unstable, and security related releases
+  - [ ] Information on branch and tag strategies
+  - [ ] Branch and platform support and length of support
+  - [ ] Artifacts included in the release.
   - Additional information on topics such as LTS and edge releases are optional. Release expectations are a social contract between the project and its end users and hence changes to these should be well thought out, discussed, socialized and as necessary agreed upon by project leadership before getting rolled out.
 
 <!-- (Project assertion goes here) --> 

--- a/.github/ISSUE_TEMPLATE/template-graduation-application.md
+++ b/.github/ISSUE_TEMPLATE/template-graduation-application.md
@@ -187,7 +187,14 @@ Note: this section may be augmented by the completion of a Governance Review fro
 
 <!-- (Project assertion goes here) --> 
 
-- [ ] **Document the project's release process.**
+- [ ] **Document the project's release process and guidelines publicly in a RELEASES.md or equivalent file that defines:** 
+
+  - [ ] release expectations (scheduled or based on feature implementation)
+  - [ ] tagging as stable, unstable, and security related releases
+  - [ ] information on branch and tag strategies
+  - [ ] branch and platform support and length of support
+  - [ ] artifacts included in the release.
+  - [ ] Additional information on topics such as LTS and edge releases are optional. Release expectations are a social contract between the project and its end users and hence changes to these should be well thought out, discussed, socialized and as necessary agreed upon by project leadership before getting rolled out.
 
 <!-- (Project assertion goes here) --> 
 

--- a/operations/toc-templates/template-dd-pr-graduation.md
+++ b/operations/toc-templates/template-dd-pr-graduation.md
@@ -184,12 +184,12 @@ Note: this section may be augmented by the completion of a Governance Review fro
 
 - [ ] **Document the project's release process and guidelines publicly in a RELEASES.md or equivalent file that defines:** 
 
-  - [ ] release expectations (scheduled or based on feature implementation)
-  - [ ] tagging as stable, unstable, and security related releases
-  - [ ] information on branch and tag strategies
-  - [ ] branch and platform support and length of support
-  - [ ] artifacts included in the release.
-  - [ ] Additional information on topics such as LTS and edge releases are optional. Release expectations are a social contract between the project and its end users and hence changes to these should be well thought out, discussed, socialized and as necessary agreed upon by project leadership before getting rolled out.
+  - [ ] Release expectations (scheduled or based on feature implementation)
+  - [ ] Tagging as stable, unstable, and security related releases
+  - [ ] Information on branch and tag strategies
+  - [ ] Branch and platform support and length of support
+  - [ ] Artifacts included in the release.
+  - Additional information on topics such as LTS and edge releases are optional. Release expectations are a social contract between the project and its end users and hence changes to these should be well thought out, discussed, socialized and as necessary agreed upon by project leadership before getting rolled out.
 
 <!-- (TOC Evaluation goes here) --> 
 

--- a/operations/toc-templates/template-dd-pr-graduation.md
+++ b/operations/toc-templates/template-dd-pr-graduation.md
@@ -182,7 +182,14 @@ Note: this section may be augmented by the completion of a Governance Review fro
 
 <!-- (TOC Evaluation goes here) --> 
 
-- [ ] **Document the project's release process.**
+- [ ] **Document the project's release process and guidelines publicly in a RELEASES.md or equivalent file that defines:** 
+
+  - [ ] release expectations (scheduled or based on feature implementation)
+  - [ ] tagging as stable, unstable, and security related releases
+  - [ ] information on branch and tag strategies
+  - [ ] branch and platform support and length of support
+  - [ ] artifacts included in the release.
+  - [ ] Additional information on topics such as LTS and edge releases are optional. Release expectations are a social contract between the project and its end users and hence changes to these should be well thought out, discussed, socialized and as necessary agreed upon by project leadership before getting rolled out.
 
 <!-- (TOC Evaluation goes here) --> 
 


### PR DESCRIPTION
The current documented release expectations for a gradated project contained a lot of room for interpretation. The TOC recently met an offsite where we discussed making these expectations more clear. There are some CNCF projects that already are going about this in a good way and this is a practice we'd like to see implemented across the board for graduated projects at a minimum:

[1] - https://github.com/kubernetes/community/blob/master/contributors/devel/sig-release/release.md
[2] - https://github.com/envoyproxy/envoy/blob/main/RELEASES.md
[3] - https://prometheus.io/docs/introduction/release-cycle/