### PR TITLE
Update TAG app delivery personell

### DIFF
--- a/tags/cncf-tags.md
+++ b/tags/cncf-tags.md
@@ -31,7 +31,6 @@ TOC and TOC Contributors have fulfilled TAG duties in the past and will continue
 * [Thomas Schuetz](https://github.com/thschue)
 
 #### Tech Leads
-* [Alex Jones](https://github.com/alexsjones)
 * [Karena Angell](https://github.com/angellk)
 * [Lian Li](https://github.com/lianmakesthings)
 

--- a/tags/cncf-tags.md
+++ b/tags/cncf-tags.md
@@ -26,13 +26,13 @@ TOC and TOC Contributors have fulfilled TAG duties in the past and will continue
 
 ### TAG App-Delivery
 #### Chairs
-* [Alois Reitbauer](https://github.com/AloisReitbauer)
+* [Lian Li](https://github.com/lianmakesthings)
 * [Josh Gavant](https://github.com/joshgav)
 * [Thomas Schuetz](https://github.com/thschue)
 
 #### Tech Leads
 * [Karena Angell](https://github.com/angellk)
-* [Lian Li](https://github.com/lianmakesthings)
+
 
 ### TAG Contributor Strategy
 #### Chairs

--- a/tags/emeritus_leaders.md
+++ b/tags/emeritus_leaders.md
@@ -4,6 +4,7 @@
 | TAG App Delivery         | [Hongchao Deng](https://github.com/hongchaodeng)         |
 | TAG App Delivery         | [Bryan Liles](https://github.com/bryanl)                 |
 | TAG App Delivery         | [Lei Zhang](https://github.com/resouer)                  |
+| TAG App Delivery         | [Alois Reitbauer](https://github.com/AloisReitbauer)     |
 | TAG App Delivery         | [Alex Jones](https://github.com/alexsjones)              |
 | TAG Contributor Strategy | [Gerred Dillon](https://github.com/gerred)               |
 | TAG Contributor Strategy | [Paris Pittman](https://github.com/parispittman)         |

--- a/tags/emeritus_leaders.md
+++ b/tags/emeritus_leaders.md
@@ -4,6 +4,7 @@
 | TAG App Delivery         | [Hongchao Deng](https://github.com/hongchaodeng)         |
 | TAG App Delivery         | [Bryan Liles](https://github.com/bryanl)                 |
 | TAG App Delivery         | [Lei Zhang](https://github.com/resouer)                  |
+| TAG App Delivery         | [Alex Jones](https://github.com/alexsjones)              |
 | TAG Contributor Strategy | [Gerred Dillon](https://github.com/gerred)               |
 | TAG Contributor Strategy | [Paris Pittman](https://github.com/parispittman)         |
 | TAG Contributor Strategy | [Stephen Augustus](https://github.com/justaugustus)      |

--- a/tags/tag-charters/app-delivery.md
+++ b/tags/tag-charters/app-delivery.md
@@ -119,7 +119,7 @@ Lifecycle management of applications is a broad and mainstream topic of Cloud Na
 
 ## **Operations**
 
-* TOC Liaisons: Katie Gamanji, Justin Cormack
+* TOC Liaisons: Katie Gamanji, Lin Sun
 * TAG chairs: [Alois Reitbauer](https://github.com/AloisReitbauer), [Thomas Schuetz](https://github.com/thschue), [Josh Gavant](https://github.com/joshgav) 
 * Tech Leads: [Alex Jones](https://github.com/AlexsJones), [Lian Li](https://github.com/lianmakesthings) 
 * See [roles](https://github.com/cncf/tag-security/blob/main/governance/roles.md#role-of-chairs) for more information

--- a/tags/tag-charters/app-delivery.md
+++ b/tags/tag-charters/app-delivery.md
@@ -121,7 +121,7 @@ Lifecycle management of applications is a broad and mainstream topic of Cloud Na
 
 * TOC Liaisons: Katie Gamanji, Lin Sun
 * TAG chairs: [Alois Reitbauer](https://github.com/AloisReitbauer), [Thomas Schuetz](https://github.com/thschue), [Josh Gavant](https://github.com/joshgav) 
-* Tech Leads: [Alex Jones](https://github.com/AlexsJones), [Lian Li](https://github.com/lianmakesthings) 
+* Tech Leads: [Karena Angell](https://github.com/angellk), [Lian Li](https://github.com/lianmakesthings)
 * See [roles](https://github.com/cncf/tag-security/blob/main/governance/roles.md#role-of-chairs) for more information
 * Slack channel: #tag-app-delivery in CNCF workspace - [https://cloud-native.slack.com/messages/CL3SL0CP5](https://cloud-native.slack.com/messages/CL3SL0CP5) 
 

--- a/tags/tag-charters/app-delivery.md
+++ b/tags/tag-charters/app-delivery.md
@@ -120,8 +120,8 @@ Lifecycle management of applications is a broad and mainstream topic of Cloud Na
 ## **Operations**
 
 * TOC Liaisons: Katie Gamanji, Lin Sun
-* TAG chairs: [Alois Reitbauer](https://github.com/AloisReitbauer), [Thomas Schuetz](https://github.com/thschue), [Josh Gavant](https://github.com/joshgav) 
-* Tech Leads: [Karena Angell](https://github.com/angellk), [Lian Li](https://github.com/lianmakesthings)
+* TAG chairs: [Lian Li](https://github.com/lianmakesthings), [Thomas Schuetz](https://github.com/thschue), [Josh Gavant](https://github.com/joshgav)
+* Tech Leads: [Karena Angell](https://github.com/angellk)
 * See [roles](https://github.com/cncf/tag-security/blob/main/governance/roles.md#role-of-chairs) for more information
 * Slack channel: #tag-app-delivery in CNCF workspace - [https://cloud-native.slack.com/messages/CL3SL0CP5](https://cloud-native.slack.com/messages/CL3SL0CP5) 
 


### PR DESCRIPTION
- Alois stepped down as Chair
- Lian was voted in as Chair and confirmed by TOC
- Alex Jones stepped down as Tech Lead
- updated some other information in various places where they were missed

@Riaankl