### PR TITLE
feat: replace TAG Security co-chair

### DIFF
--- a/tags/cncf-tags.md
+++ b/tags/cncf-tags.md
@@ -82,12 +82,12 @@ TOC and TOC Contributors have fulfilled TAG duties in the past and will continue
 * [Alexander Kanevskiy](https://github.com/kad)
 * [Klaus Ma](https://github.com/k82cn)
 * [Rajas Kakodkar](https://github.com/rajaskakodkar)
-  
+
 ### TAG Security
 #### Chairs
-* [Andrew Martin](https://github.com/sublimino)
 * [Marina Moore](https://github.com/mnm678)
 * [Pushkar Joglekar](https://github.com/pushkarj)
+* [Eddie Knight](https://github.com/eddie-knight)
 
 #### Tech Leads
 * [Ash Narkar](https://github.com/ashutosh-narkar)


### PR DESCRIPTION
Adds @eddie-knight to replace me as TAG Security Co-Chair via https://github.com/cncf/tag-security/issues/1250