### PR TITLE
correct toc election link

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -5,7 +5,7 @@ A FAQ geared towards CNCF TOC and project issues.
 ## How do I join the TOC?
 
 The TOC is a body elected by a variety of constituents. There is a public election schedule:
-https://github.com/cncf/toc/blob/main/process/election-schedule.md
+https://github.com/cncf/toc/blob/main/operations/election-schedule.md
 
 The best way to get involved is to start attending TOC meetings and especially by participating in TAG(s)/WG(s).
 


### PR DESCRIPTION
https://github.com/cncf/toc/blob/main/operations/election-schedule.md

Same issue for the official website: https://www.cncf.io/people/technical-oversight-committee/
- the _**schedule**_ link is 404 as well, but I don't know the way to fix the website.

![image](https://github.com/cncf/toc/assets/2010320/4f7aff72-60c6-4ad7-87cd-72201a01e6bb)
