### PR TITLE
Add README and charter templates

### DIFF
--- a/tags/resources/tag-formation-templates/README.md
+++ b/tags/resources/tag-formation-templates/README.md
@@ -6,8 +6,10 @@ The files have placeholders marked with `<TAG-NAME>` or similar.
 **Templates**:
 - [Artifact publishing guidelines](template-artifact-publishing-guidelines.md)
 - [Blog post process](template-blog-post-process.md)
+- [Charter template](./template-tag-charter.md)
 - [CONTRIBUTING](template-contributing.md)
 - [Leadership election process](template-leadership-election-process.md)
 - [Leadership Structure](template-leadership-structure.md)
+- [README template](./template-tag-readme.md)
 - [TAG Roles](template-roles.md)
 - [Whitepaper process](template-whitepaper-process.md)

--- a/tags/resources/tag-formation-templates/template-tag-charter.md
+++ b/tags/resources/tag-formation-templates/template-tag-charter.md
@@ -1,0 +1,32 @@
+## Template for Charter Document layout:
+
+**Founding members / Authors (Optional)**
+
+This provides historical attribution.
+
+**Introduction**
+
+The introduction should provide reasoning about why the TAG is needed in the ecosystem.  This can then be leveraged in the evaluation and be refreshed as the TAGs ecosystem evolves.
+
+**Mission**
+
+The mission statement should provide what the TAG is doing within the confines of the CNCF and cloud native. What makes the TAG’s work indispensable in the Cloud native ecosystem?
+
+**Responsibilities & Deliverables**
+
+
+
+* **Background** 
+
+     Optional
+
+* **Areas In-Scope**
+    * This is what the TAG considers a part of their mandate.
+* **Areas Out of scope**
+    * This is what the TAG considers to be not a part of their mandate.
+* **Deliverables to the TOC** - Accountability 
+    * This should be part out the outcome of the current discussion about the mutual expectations between TOC / TAG
+
+**Interface with other TAGs and Interested parties**
+
+Here TAGs can mention related groups and interfacing with other TAGs.

--- a/tags/resources/tag-formation-templates/template-tag-readme.md
+++ b/tags/resources/tag-formation-templates/template-tag-readme.md
@@ -1,0 +1,34 @@
+## Template for README Document layout
+
+**Introduction**
+
+Overview Information about the TAG
+
+**Project List**
+
+Hyperlink with a filtered CNCF Landscape link
+
+**Governance / Leadership**
+
+Hyperlink to TOC repository for TAG Chairs and Tech Leads. \
+TOC approves TAG leads and Tech Leads via PR in the cncf/toc repo.
+
+Working group and initiative leadership is agreed between the TAG and their liaison and is listed in the README
+
+**TAG Structures**
+
+- Working groups & Initiatives
+
+**Meeting administration**
+
+List and link meetings & agenda documents
+
+**Roadmap**
+
+Ideally each TAG has a roadmap, but it should be managed independently of the TAG charter 
+
+Hyperlinked to the Roadmap document - template to be provided - This must still be developed.
+
+**Charter:**
+
+Hyperlinked to the TOC repo charter file


### PR DESCRIPTION
Add templates for TAGs to use where rewriting the Charter and README. 
This folder contain several place holder template documents that still need to be created, therefore this seen to best place for these templates.