### PR TITLE
Add vote announcements to TOC votes

### DIFF
--- a/.gitvote.yml
+++ b/.gitvote.yml
@@ -16,3 +16,7 @@ profiles:
         - cncf-toc
       exclude_team_maintainers: true
     close_on_passing: true
+  announcements:
+     discussions:
+       category: announcements 
+       

--- a/.gitvote.yml
+++ b/.gitvote.yml
@@ -8,6 +8,9 @@ profiles:
         - cncf-toc
       exclude_team_maintainers: true
     close_on_passing: true
+    announcements:
+      discussions:
+        category: announcements
   1wk:
     duration: 1w
     pass_threshold: 66
@@ -16,6 +19,3 @@ profiles:
         - cncf-toc
       exclude_team_maintainers: true
     close_on_passing: true
-  announcements:
-     discussions:
-       category: announcements

--- a/.gitvote.yml
+++ b/.gitvote.yml
@@ -18,5 +18,4 @@ profiles:
     close_on_passing: true
   announcements:
      discussions:
-       category: announcements 
-       
+       category: announcements


### PR DESCRIPTION
Adding the new [Git Vote Announcements Function](https://github.com/cncf/gitvote?tab=readme-ov-file#announcements) to the TOC votes.

This would result in an announcement in the TOC Git Hub Discussions under [Announcements](https://github.com/cncf/toc/discussions/categories/announcements) as soon as a vote is concluded. The Announcements Announcement Discussion tag not used for anything else at this time, so it should be a good fit.

We might want to "market" this outcome so people know to subscribe to the Announcements channel.