### PR TITLE
Remove duplicate onboarding tasks, group tasks by topic.

### DIFF
--- a/.github/ISSUE_TEMPLATE/project-onboarding.md
+++ b/.github/ISSUE_TEMPLATE/project-onboarding.md
@@ -3,10 +3,10 @@ name: Project onboarding for Sandbox projects
 about: Create a checklist of tasks for a project to complete the onboarding process
 title: "[SANDBOX PROJECT ONBOARDING] project"
 labels: project onboarding, sandbox
-assignees: caniszczyk, idvoretskyi, jeefy, krook, Cmierly
+assignees: caniszczyk, idvoretskyi, jeefy, krook, mrbobbytables, Cmierly
 ---
 
-Welcome to CNCF Project Onboarding!
+# Welcome to CNCF Project Onboarding!
 
 This is an issue created to help onboard your project into the CNCF after the TOC has voted to accept your project into the Sandbox.
 
@@ -14,42 +14,40 @@ We would like your project to complete onboarding within one month of acceptance
 
 Please track your progress by using "Quote reply" to create your own copy of this checklist in an issue, so that you can update the status as you finish items.
 
-**From the project side, please ensure that:**
+## Review and understand
 
-- [ ] You understand the [project proposal process and requirements](https://github.com/cncf/toc/blob/main/process/README.md).
-- [ ] You understand the [services available for your project at CNCF](https://www.cncf.io/services-for-projects/).
-- [ ] You ensure your project meets the [CNCF IP Policy](https://github.com/cncf/foundation/blob/master/charter.md#11-ip-policy).
-- [ ] You review the [online programs guidelines](https://github.com/cncf/foundation/blob/master/online-programs-guidelines.md).
-- [ ] You understand the [trademark guidelines](https://www.linuxfoundation.org/en/trademark-usage).
-- [ ] You understand the [license allowlist](https://github.com/cncf/foundation/blob/master/allowed-third-party-license-policy.md#approved-licenses-for-allowlist).
-- [ ] Your project is working on [written, open governance](https://contribute.cncf.io/maintainers/governance/).
-- [ ] Your Slack channels (if any) are migrated to the [Kubernetes or CNCF Slack workspace](https://slack.com/help/articles/217872578-Import-data-from-one-Slack-workspace-to-another).
-- [ ] Your project is in its own separate neutral GitHub organization. This will make it transferable to the CNCF's GitHub Enterprise account.
-- [ ] You submit a [pull request](https://github.com/cncf/landscape/pulls) to add your project as a Sandbox project to the [Cloud Native Landscape](https://landscape.cncf.io) by updating [landscape.yml](https://github.com/cncf/landscape/blob/master/landscape.yml) following these [instructions](https://github.com/cncf/landscape2/blob/main/docs/config/data.yml).
-- [ ] You create a maintainer list and add it to the [aggregated CNCF maintainer list](https://maintainers.cncf.io) via pull request.
-- [ ] You submit a [pull request](https://github.com/cncf/artwork) with your artwork.
-- [ ] You [transfer your domain to the CNCF](https://jira.linuxfoundation.org/plugins/servlet/theme/portal/2/create/63).
+- [ ] The [project proposal process and requirements](https://github.com/cncf/toc/blob/main/process/README.md).
+- [ ] The [services available for your project at the CNCF](https://www.cncf.io/services-for-projects/).
+- [ ] The [CNCF IP Policy](https://github.com/cncf/foundation/blob/master/charter.md#11-ip-policy).
+- [ ] The [trademark guidelines](https://www.linuxfoundation.org/en/trademark-usage).
+- [ ] The [license allowlist](https://github.com/cncf/foundation/blob/master/allowed-third-party-license-policy.md#approved-licenses-for-allowlist).
+- [ ] The [online program guidelines](https://github.com/cncf/foundation/blob/master/online-programs-guidelines.md).
+- [ ] Optional: [Book time with CNCF staff](http://project-meetings.cncf.io) for any onboarding questions.
 
-**Things that CNCF will need from the project:**
+## Contribute and transfer
 
-- [ ] Provide emails for the maintainers to get access to the maintainers mailing list and Service Desk. Email them to <project-onboarding@cncf.io>.
-- [ ] Transfer any [trademark and logo assets to the Linux Foundation](https://github.com/cncf/foundation/tree/master/agreements).
+- [ ] Move your project to its own separate neutral GitHub organization. This will make it transferable to the CNCF's GitHub Enterprise account. If it's already in a GHE account, you will need to remove it from that first.
 - [ ] Accept the invite to join the CNCF GitHub Enterprise account. We'll then add `thelinuxfoundation` as an organization owner to ensure neutral hosting of your project.
-- [ ] Ensure that [DCO](https://github.com/apps/dco) or [CLA](https://github.com/cncf/cla) are enabled for all GitHub repositories of the project
-- [ ] Ensure that that the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md) (or your adopted version of it) are explicitly referenced at the project's README on GitHub.
-- [ ] Ensure LF footer is on your website and [guidelines](https://github.com/cncf/foundation/blob/master/website-guidelines.md) followed (if your project doesn't have a dedicated website, please adopt those guidelines for the README file of your project on GitHub).
+- [ ] Migrate your Slack channels (if any) to the [Kubernetes or CNCF Slack workspace](https://slack.com/help/articles/217872578-Import-data-from-one-Slack-workspace-to-another). CNCF staff can help.
+- [ ] Submit a [pull request](https://github.com/cncf/landscape/pulls) to add your project as a Sandbox project to the [Cloud Native Landscape](https://landscape.cncf.io) by updating [landscape.yml](https://github.com/cncf/landscape/blob/master/landscape.yml) following these [instructions](https://github.com/cncf/landscape2/blob/main/docs/config/data.yml).
+- [ ] Transfer [your domain to the CNCF](https://jira.linuxfoundation.org/plugins/servlet/theme/portal/2/create/63). The "LF Stakeholder email" is <projects@cncf.io>
+- [ ] Transfer any [trademark and logo assets to the Linux Foundation](https://github.com/cncf/foundation/tree/master/agreements).
+- [ ] Submit a [pull request](https://github.com/cncf/artwork) with your artwork.
 - [ ] Transfer website analytics to <projects@cncf.io>.
+
+## Update and document
+
+- [ ] Ensure that [DCO](https://github.com/apps/dco) (preferred) or [CLA](https://github.com/cncf/cla) are enabled for all GitHub repositories of the project
+- [ ] Ensure that that the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md) (or your adopted version of it) are explicitly referenced at the project's README on GitHub.
+- [ ] Ensure LF footer is on your website and [guidelines](https://github.com/cncf/foundation/blob/master/website-guidelines.md) followed (if your project doesn't have a dedicated website, please adopt those guidelines for the README file).
+- [ ] Ceate a maintainer list and add it to the [aggregated CNCF maintainer list](https://maintainers.cncf.io) via pull request.
+- [ ] Provide emails for the maintainers to get access to the maintainers mailing list and Service Desk. Email them to <project-onboarding@cncf.io>.
+- [ ] Start working on [written, open governance](https://contribute.cncf.io/maintainers/governance/).
+- [ ] Adopt a license scanning tool, like [FOSSA](https://fossa.com/) or [Snyk](https://snyk.io/). Staff can grant access.
 - [ ] Start on an [OpenSSF Best Practices Badge](https://bestpractices.coreinfrastructure.org/en).
 
-**Things that the CNCF will do or help the project to do:**
+## CNCF staff tasks
 
-- [ ] Add your project to [DevStats](https://devstats.cncf.io/).
-- [ ] Add your project to [LFX Insights](https://insights.lfx.linuxfoundation.org/). This is done by adding a read-only app added to your GitHub organization.
-- [ ] Update relevant marketing intros and slide decks.
-- [ ] Update event call for papers, registration, and CFP area forms.
-- [ ] Confirm maintainers have read about what's available through the [Service Desk](https://www.cncf.io/services-for-projects/).
-- [ ] CNCF sends a welcome email to confirm maintainer list access.
-- [ ] [Book time between maintainers and CNCF staff](http://project-meetings.cncf.io).
-- [ ] Create space for meetings/events on the [CNCF Community Groups page](https://community.cncf.io). More [details](https://github.com/cncf/communitygroups/blob/main/README.md#cncf-projects).
-- [ ] Create new Slack channel(s) on the Kubernetes or CNCF Slack workspace if needed.
-- [ ] Adopt a license scanning tool, like [FOSSA](https://fossa.com/) or [Snyk](https://snyk.io/)
+- [ ] Add the project to [DevStats](https://devstats.cncf.io/).
+- [ ] Add the project to [LFX Insights](https://insights.lfx.linuxfoundation.org/). This is done by adding a read-only app to your GitHub organization once it's in CNCF GHE.
+- [ ] Send a welcome email to confirm maintainer list access.


### PR DESCRIPTION
This change to the Sandbox onboarding issue template makes a few formatting changes to avoid confusion and vagaries while onboarding.

The tasks are now grouped into logical areas and duplicates (like migrating Slack channels) are removed but the substance is the same.

Please do not merge until reviewed.