### PR TITLE
Add Projects Team sync when a project moves a level

### DIFF
--- a/process/README.md
+++ b/process/README.md
@@ -83,6 +83,10 @@ While the details of the process are described in detail further for Incubating 
 
 * If the vote passes (2/3 supermajority vote of the TOC), the results are emailed and the project is placed in the 'Done' state on the project board.
 * An announcement is made conveying the project name and its new level status.
+* Projects are encouraged to [book a slot with the CNCF Project team](https://calendly.com/d/hkb-rf6-hzr/30-minutes-w-cncf-projects-team?month=2024-08) for a review of project benefits. This includes:
+  - Reviewing of all benefits to ensure maintainers understand the resources available for their project
+  - Introduction to the event team and other logistical information important for the project to be successful at CNCF Events
+  - Acts as a checkpoint between the project and CNCF Staff to ensure that the project is getting the support they need while moving to a new level.   
 
 #### Criteria
 


### PR DESCRIPTION
This seems like the right place for this but I can move it wherever. Basically when a project graduates we'd like to meet with them, get the congratulations out of the way, and then go over all of the project benefits at that level, answer questions about their benefits, that sort of thing. 

This will include a rebrief from the events team or a representative so projects understand how KubeCon works from a logistical perspective.