### PR TITLE
Add CNCF Project team meetings to templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/project-onboarding.md
+++ b/.github/ISSUE_TEMPLATE/project-onboarding.md
@@ -22,7 +22,7 @@ Please track your progress by using "Quote reply" to create your own copy of thi
 - [ ] The [trademark guidelines](https://www.linuxfoundation.org/legal/trademark-usage).
 - [ ] The [license allowlist](https://github.com/cncf/foundation/blob/main/allowed-third-party-license-policy.md#approved-licenses-for-allowlist).
 - [ ] The [online program guidelines](https://github.com/cncf/foundation/blob/main/online-programs-guidelines.md).
-- [ ] Optional: [Book time with CNCF staff](http://project-meetings.cncf.io) for any onboarding questions.
+- [ ] [Book time with CNCF staff](http://project-meetings.cncf.io) to understand project benefits and event resources.
 
 ## Contribute and transfer
 

--- a/.github/ISSUE_TEMPLATE/template-graduation-application.md
+++ b/.github/ISSUE_TEMPLATE/template-graduation-application.md
@@ -17,6 +17,8 @@ Communication: $SLACK
 
 Project points of contacts: $NAME, $EMAIL
 
+- [ ] (Post Incubation only) [Book a meeting with CNCF staff](http://project-meetings.cncf.io) to understand project benefits and event resources. 
+
 ## Graduation Criteria Summary for $PROJECT
 
 ### Adoption Assertion

--- a/.github/ISSUE_TEMPLATE/template-graduation-application.md
+++ b/.github/ISSUE_TEMPLATE/template-graduation-application.md
@@ -17,7 +17,7 @@ Communication: $SLACK
 
 Project points of contacts: $NAME, $EMAIL
 
-- [ ] (Post Incubation only) [Book a meeting with CNCF staff](http://project-meetings.cncf.io) to understand project benefits and event resources. 
+- [ ] (Post Graduation only) [Book a meeting with CNCF staff](http://project-meetings.cncf.io) to understand project benefits and event resources. 
 
 ## Graduation Criteria Summary for $PROJECT
 

--- a/.github/ISSUE_TEMPLATE/template-incubation-application.md
+++ b/.github/ISSUE_TEMPLATE/template-incubation-application.md
@@ -16,6 +16,8 @@ Communication: $SLACK
 
 Project points of contacts: $NAME, $EMAIL
 
+- [ ] (Post Incubation only) [Book a meeting with CNCF staff](http://project-meetings.cncf.io) to understand project benefits and event resources. 
+
 ## Incubation Criteria Summary for $PROJECT
 
 ### Adoption Assertion


### PR DESCRIPTION
After syncing with jeefy/bob we think this is probably a decent place to put these items. 

This ensures that each incoming project and every project moving level books a meeting with the project team. Our team covers event resources, briefing on all the contribute.cncf.io resources, benefits at KubeCon, and ensuring project reps are invited to the maintainer's circle slack. 