### PR TITLE
Remove Andrés Vega from TAG Security

### DIFF
--- a/tags/cncf-tags.md
+++ b/tags/cncf-tags.md
@@ -96,7 +96,6 @@ TOC and TOC Contributors have fulfilled TAG duties in the past and will continue
 |-----------------------|------------------------|
 | [Justin Cappos](https://github.com/JustinCappos)       | New York University    |
 | [Ash Narkar](https://github.com/ashutosh-narkar)       | Styra                  |
-| [Andrés Vega](https://github.com/anvega)               | M42                    | 
 | [Ragashree Shekar](https://github.com/ragashreeshekar) | Independent            |
 | [Michael Lieberman](https://github.com/mlieberman85)   | Kusari                 | 
 | [John Kjell](https://github.com/kjell)                 | TestifySec             | 


### PR DESCRIPTION
As stated in https://github.com/cncf/tag-security/issues/1349, I am transitioning from my role as Technical Leader in CNCF TAG Security, stepping back from day-to-day maintainer-like responsibilities.

I'm stepping down from the role but will remain available for guidance and collaboration when needed. You can continue to find me online.

I encourage the team to continue innovating, challenging assumptions, and supporting each other. Adaptability, teamwork, and embracing diverse perspectives have been crucial to our success. Continuing to prioritize these values, along with mutual respect and tactful communication, will drive future breakthroughs.

Thank you for the opportunity to contribute to the group. The collaborative effort to build ecosystem security has been meaningful. The friendships made through our efforts have strengthened our community. 