### PR TITLE
Add Application Level Context to Incubation and Graduation Application Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/template-graduation-application.md
+++ b/.github/ISSUE_TEMPLATE/template-graduation-application.md
@@ -236,7 +236,7 @@ Note: this section may be augmented by a joint-assessment performed by TAG Secur
 
 <!-- (Project assertion goes here) --> 
 
-- [ ] **Document Security Self-Assessment.**
+- [ ] **Document [Security Self-Assessment](https://tag-security.cncf.io/community/assessments/guide/self-assessment/).**
 
 <!-- (Project assertion goes here) --> 
 

--- a/.github/ISSUE_TEMPLATE/template-graduation-application.md
+++ b/.github/ISSUE_TEMPLATE/template-graduation-application.md
@@ -6,7 +6,7 @@ labels: graduation
 ---
 
 # $PROJECT Graduation Application
-v1.5
+v1.6
 This template provides the project with a framework to inform the TOC of their conformance to the Graduation Level Criteria. 
 
 
@@ -20,6 +20,10 @@ Project points of contacts: $NAME, $EMAIL
 - [ ] (Post Graduation only) [Book a meeting with CNCF staff](http://project-meetings.cncf.io) to understand project benefits and event resources. 
 
 ## Graduation Criteria Summary for $PROJECT
+
+### Application Level Assertion
+
+- [ ] This project is currently Incubating, accepted on YYYYMMDD, and applying to Graduate.
 
 ### Adoption Assertion
 

--- a/.github/ISSUE_TEMPLATE/template-incubation-application.md
+++ b/.github/ISSUE_TEMPLATE/template-incubation-application.md
@@ -20,6 +20,11 @@ Project points of contacts: $NAME, $EMAIL
 
 ## Incubation Criteria Summary for $PROJECT
 
+### Application Level Assertion
+
+- [ ] This project is currently Sandbox, accepted on YYYYMMDD, and applying to Incubation.
+- [ ] This project is applying to join the CNCF at the Incubation level.
+
 ### Adoption Assertion
 
 _The project has been adopted by the following organizations in a testing and integration or production capacity:_

--- a/.github/ISSUE_TEMPLATE/template-incubation-application.md
+++ b/.github/ISSUE_TEMPLATE/template-incubation-application.md
@@ -6,7 +6,7 @@ labels: incubation
 ---
 
 # $PROJECT Incubation Application
-v1.5
+v1.6
 This template provides the project with a framework to inform the TOC of their conformance to the Incubation Level Criteria. 
 
 Project Repo(s): $URL

--- a/.github/ISSUE_TEMPLATE/template-incubation-application.md
+++ b/.github/ISSUE_TEMPLATE/template-incubation-application.md
@@ -204,7 +204,7 @@ Note: this section may be augmented by the completion of a Governance Review fro
 
 ## Security
 
-Note: this section may be augemented by a joint-assessment performed by TAG Security.
+Note: this section may be augmented by a joint-assessment performed by TAG Security.
 
 ### Suggested
 
@@ -224,7 +224,7 @@ N/A
 
 <!-- (Project assertion goes here) --> 
 
-- [ ] **Document Security Self-Assessment.**
+- [ ] **Document [Security Self-Assessment](https://tag-security.cncf.io/community/assessments/guide/self-assessment/).**
 
 <!-- (Project assertion goes here) --> 
 


### PR DESCRIPTION
Per #1350 , added context for projects to assert eligibility for the CNCF level applying to.

Also, added URL for Security Self Assessment as it is not clear where to go for projects not familiar with it.