### PR TITLE
Unnecessary section in template-graduation-application markdown

### DIFF
--- a/.github/ISSUE_TEMPLATE/template-graduation-application.md
+++ b/.github/ISSUE_TEMPLATE/template-graduation-application.md
@@ -29,8 +29,6 @@ Project points of contacts: $NAME, $EMAIL
 
 _The project has been adopted by the following organizations in a testing and integration or production capacity:_
 
-### Criteria
-
 ## Application Process Principles
 
 ### Suggested


### PR DESCRIPTION
In the cert-manager submission, we left this empty. found it again in Dapr due diligence and could not figure out what is needed here. 

Do we really need this? if not let's remove it please.