### PR TITLE
Update TAG Environmental Sustainability charter document

### DIFF
--- a/tags/tag-charters/environmentalsustainability.md
+++ b/tags/tag-charters/environmentalsustainability.md
@@ -1,8 +1,12 @@
 # CNCF TAG Environmental Sustainability
 
+## Authors
+
+Primary Authors: Marlow Weston, Leonard Vincent Simon Pahlke, Max Körbächer
+
 ## Introduction
 
-The Paris Climate Accords outline the link between economic activity, greenhouse gas (GHG) emissions, and the impacts of climate change. GHG  emissions, primarily made from Carbon Dioxide, are released during the combustion of fossil fuels to produce electricity. To reach net zero goals, we will first identify how to reduce the environmental footprints of increasingly large data centers and then help the community take action to mitigate these footprints.
+The Paris Climate Accords outline the link between economic activity, greenhouse gas (GHG) emissions, and the impacts of climate change. GHG emissions, primarily made from Carbon Dioxide, are released during the combustion of fossil fuels to produce electricity. To reach net zero goals, we will first identify how to reduce the environmental footprints of increasingly large data centers and then help the community take action to mitigate these footprints.
 
 References:
 
@@ -10,18 +14,19 @@ References:
 * https://www.whitehouse.gov/wp-content/uploads/2021/10/US-Long-Term-Strategy.pdf
 * https://www.worldbank.org/en/news/feature/2022/05/23/what-you-need-to-know-about-net-zero
 
-## Mission Statement
-This TAG's goal is to advocate for, develop, support, and help evaluate environmental sustainability initiatives in cloud native technologies.  This TAG will identify values and possible incentives for service providers to reduce their consumption and carbon footprint through cloud native tooling.
+## Mission
+
+This TAG's goal is to advocate for, develop, support, and help evaluate environmental sustainability initiatives in cloud native technologies. This TAG will identify values and possible incentives for service providers to reduce their consumption and carbon footprint through cloud native tooling.
 
 ## Responsibilities & Deliverables
 
 ### Background
+
 We recognize that: 
 - the trade off between reducing resource consumption and higher performance is hard to balance
 - there is a lack of well supported and documented approaches for evaluating the environmental sustainability of cloud native projects in their default or optimized configurations
 
-
-### In-Scope
+### Areas In-Scope
 
 - Identify, define, and develop tooling to assess and improve environmental sustainability approaches, including
     - Quantify the energy consumption of cloud native implementations individually as well as in common integration patterns
@@ -30,26 +35,30 @@ We recognize that:
 - Community outreach and engagement on the work of this TAG
 - Collaboration with other environmental or sustainability organizations, initiatives, activities, and efforts that may fall outside of the CNCF (Cloud Native Computing Foundation)
 
-### Out of scope
+### Areas Out of scope
+
 - Form an umbrella organization beyond the CNCF
 - Establish a compliance and standards body beyond the CNCF space
 - Evaluate individual company infrastructures
 - Focus outside of cloud native technologies, according to the [CNCF Cloud Native definition](https://github.com/cncf/toc/blob/main/DEFINITION.md)
 
-## Deliverables to TOC
+## Deliverables to the TOC - Accountability
+
 - Landscape for carbon and energy efficiency in the form of metrics, measurements, and management techniques
 - Environmental sustainability recommendations and optimizations to new and existing projects within the landscape
 - Reports on gaps in the environmental sustainability coverage of the landscape
 - Reviews, inputs, and recommendations for proposed projects for CNCF hosting and advancement
 - Suggestions for improvements for CNCF internal processes, for example, education for sustainability
 
-## Audiences
+## Interface with other TAGs and Interested parties
 
-- Education - audience is end users, developers, stakeholders
-- Project intelligence - audience is TOC/CNCF Community
-- External collaboration - organizations, initiatives, activities, and efforts outside of CNCF (Cloud Native Computing Foundation)
+As part of the work we do we interact both with friendly organizations like [Green Software Foundation](https://greensoftware.foundation), [Green Web Foundation](https://www.thegreenwebfoundation.org), etc., as well as multiple TAGs and projects within CNCF.
+To name a few of the TAGs and projects that we have collaborated with:
 
-## Operations
+- [TAG Observability](https://tag-observability.cncf.io)
+- [TAG App Delivery](https://tag-app-delivery.cncf.io)
+- [Falco project](https://github.com/falcosecurity/falco)
+- [Kepler project](https://github.com/sustainable-computing-io/kepler)
+- [OpenTelemetry project](https://github.com/open-telemetry)
 
-Environmental Sustainability TAG operations are consistent with standard TAG operating guidelines provided by the [CNCF Technical Oversight Committee TOC](https://github.com/cncf/toc).
-
+Environmental sustainability domain is not isolated but applies to any project or area of technology, therefore we believe that the involvement of this TAG across the CNCF landscape will keep increasing.


### PR DESCRIPTION
Added minor modifications to the TAG Environmental Sustainability charter document according to the [template](https://github.com/cncf/toc/blob/main/tags/resources/tag-formation-templates/template-tag-charter.md)

Related to https://github.com/cncf/tag-env-sustainability/issues/457