### PR TITLE
Add missing "Suggested" section to Engineering Principles on Graduation DD template

### DIFF
--- a/operations/toc-templates/template-dd-pr-graduation.md
+++ b/operations/toc-templates/template-dd-pr-graduation.md
@@ -162,6 +162,12 @@ Note: this section may be augmented by the completion of a Governance Review fro
 
 ## Engineering Principles
 
+### Suggested
+
+N/A
+
+### Required
+
 - [ ] **Document project goals and objectives that illustrate the project’s differentiation in the Cloud Native landscape as well as outlines how this project fulfills an outstanding need and/or solves a problem differently.**
 
 <!-- (TOC Evaluation goes here) --> 


### PR DESCRIPTION
Added missing Suggestion section under Engineering Principles per @TheFoxAtWork 

xref: https://github.com/cncf/toc/issues/1455