### PR TITLE
Fix Code of Conduct requirement.

### DIFF
--- a/.github/ISSUE_TEMPLATE/template-graduation-application.md
+++ b/.github/ISSUE_TEMPLATE/template-graduation-application.md
@@ -117,7 +117,7 @@ Note: this section may be augmented by the completion of a Governance Review fro
 
 <!-- (Project assertion goes here) --> 
 
-- [ ] **Document agreement that project will adopt CNCF Code of Conduct.**
+- [ ] **Document adoption of the CNCF Code of Conduct**
 
 <!-- (Project assertion goes here) --> 
 

--- a/.github/ISSUE_TEMPLATE/template-incubation-application.md
+++ b/.github/ISSUE_TEMPLATE/template-incubation-application.md
@@ -120,7 +120,7 @@ Note: this section may be augmented by the completion of a Governance Review fro
 
 <!-- (Project assertion goes here) --> 
 
-- [ ] **Document agreement that project will adopt CNCF Code of Conduct.**
+- [ ] **Document adoption of the CNCF Code of Conduct**
 
 <!-- (Project assertion goes here) --> 
 


### PR DESCRIPTION
Both the incubating and graduating templates have this requirement:

- [ ] **Document agreement that project will adopt CNCF Code of Conduct.**

This doesn't make any sense, since a CNCF project is required to adopt the CNCF CoC by the end of onboarding.  They don't get to wait until Graduation.  As such, I've replaced it with this requirement:

- [ ] **Document adoption of the CNCF Code of Conduct**