### PR TITLE
Add tools to create tag reboot automated readme files

### DIFF
--- a/.github/workflows/tags_yaml_branch_pr_processing.yaml
+++ b/.github/workflows/tags_yaml_branch_pr_processing.yaml
@@ -1,0 +1,60 @@
+name: Generate README on Tags Change (Local Branch)
+
+on:
+  pull_request_target:
+    branches:
+      - main
+    paths:
+      - tags.yaml
+  workflow_dispatch:
+    inputs:
+      check_all_prs:
+        description: 'Check all open pull requests?'
+        type: boolean
+        required: false
+        default: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update-readme-local:
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: 'stable'
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+
+      - name: Run readme_app.go
+        run: |
+          cd generator
+          go run readme_app.go
+          cd ..
+
+      - name: Commit and push changes if any
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git add .
+          if [ -n "$(git status --porcelain)" ]; then
+            git commit -m "Update README based on tags.yaml changes"
+            git push origin HEAD:${{ github.event.pull_request.head.ref }}
+          else
+            echo "No changes to commit"
+          fi

--- a/.github/workflows/tags_yaml_fork_pr_processing.yaml
+++ b/.github/workflows/tags_yaml_fork_pr_processing.yaml
@@ -1,0 +1,90 @@
+name: Generate README on Tags Change (Forked PR)
+
+on:
+  pull_request_target:
+    branches:
+      - main
+    paths:
+      - tags.yaml
+  workflow_dispatch:
+    inputs:
+      check_all_prs:
+        description: 'Check all open pull requests?'
+        type: boolean
+        required: false
+        default: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update-readme-fork:
+    # This job runs only if the PR is coming from a fork.
+    if: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}  # Ensure branch checkout
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: 'stable'
+
+      - name: Configure Git
+        run: |
+          git config --global user.name "github-actions"
+          git config --global user.email "github-actions@github.com"
+
+      - name: Create new PR, comment and close original (forked PR)
+        env:
+          # Use a different token here for fork PRs if needed.
+          GITHUB_TOKEN: ${{ secrets.TAGS_YAML_UPDATE_GHA }}
+        run: |
+          set -e
+          cp tags.yaml /tmp/tags.yaml
+          BRANCH_NAME=readme-update-fork-${{ github.event.pull_request.number }}
+          git remote set-url origin https://github.com/${{ github.repository }}.git
+          git fetch origin main
+          git checkout -B $BRANCH_NAME origin/main
+          cp /tmp/tags.yaml tags.yaml
+          cd generator
+          go run readme_app.go
+          cd ..
+          git config --global user.name "github-actions"
+          git config --global user.email "github-actions@github.com"
+          git add .
+          if ! git diff --staged --quiet; then
+            git commit -m "Update README based on tags.yaml changes"
+            git push origin $BRANCH_NAME --force
+            PR_TITLE="Update README based on tags.yaml changes from fork PR #${{ github.event.pull_request.number }}"
+            PR_BODY="This PR updates the README file based on changes in tags.yaml from fork PR #${{ github.event.pull_request.number }}."
+            API_URL=https://api.github.com/repos/${{ github.repository }}/pulls
+            PR_DATA=$(jq -n --arg title "$PR_TITLE" --arg head "$BRANCH_NAME" --arg base "${{ github.event.pull_request.base.ref }}" --arg body "$PR_BODY" '{title: $title, head: $head, base: $base, body: $body}')
+            RESPONSE=$(curl -s -X POST -H "Authorization: token $GITHUB_TOKEN" -H "Content-Type: application/json" -d "$PR_DATA" $API_URL)
+            echo "PR creation response: $RESPONSE"
+            NEW_PR_NUMBER=$(echo "$RESPONSE" | jq -r '.number')
+            if [ "$NEW_PR_NUMBER" = "null" ]; then
+              echo "Error: PR not created. API response: $RESPONSE"
+              exit 1
+            fi
+            ORIGINAL_COMMENT="This PR has been superseded by [PR #$NEW_PR_NUMBER](https://github.com/${{ github.repository }}/pull/$NEW_PR_NUMBER). Closing this PR."
+            ORIGINAL_COMMENT_API_URL=https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments
+            ORIGINAL_COMMENT_DATA=$(jq -n --arg body "$ORIGINAL_COMMENT" '{body: $body}')
+            curl -s -X POST -H "Authorization: token $GITHUB_TOKEN" -H "Content-Type: application/json" -d "$ORIGINAL_COMMENT_DATA" $ORIGINAL_COMMENT_API_URL
+            CLOSE_API_URL=https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}
+            curl -s -X PATCH -H "Authorization: token $GITHUB_TOKEN" -H "Content-Type: application/json" -d '{ "state": "closed" }' $CLOSE_API_URL
+            NEW_PR_COMMENT="This PR replaces fork PR [#${{ github.event.pull_request.number }}](https://github.com/${{ github.repository }}/pull/${{ github.event.pull_request.number }})."
+            NEW_PR_COMMENT_API_URL=https://api.github.com/repos/${{ github.repository }}/issues/$NEW_PR_NUMBER/comments
+            NEW_PR_COMMENT_DATA=$(jq -n --arg body "$NEW_PR_COMMENT" '{body: $body}')
+            curl -s -X POST -H "Authorization: token $GITHUB_TOKEN" -H "Content-Type: application/json" -d "$NEW_PR_COMMENT_DATA" $NEW_PR_COMMENT_API_URL
+          else
+            echo "No changes to commit"
+          fi

--- a/generator/README.md
+++ b/generator/README.md
@@ -1,0 +1,119 @@
+# TAG and TOC Subproject README Generator
+
+This folder contains a Go program (`readme_app.go`) that automates the generation of README files for Technical Advisory Groups (TAGs) and TOC Subprojects. The README files are populated with data from the `tags.yaml` file.
+
+## Purpose
+
+The primary goals of this program are to:
+
+* **Centralize Data:** Maintain all TAG and TOC Subproject information in a single, authoritative source (`tags.yaml`).
+* **Automate README Creation:** Generate consistent and up-to-date README files, reducing manual effort and potential inconsistencies.
+* **Streamline Updates:** Simplify the process of updating TAG and TOC Subproject information.
+
+## How it Works
+
+1.  **`tags.yaml` as the Data Source:**
+
+    * The `tags.yaml` file in the project root holds all the essential details for each TAG and TOC Subproject. This includes:
+        * Name
+        * Mission statement
+        * Leadership (Chairs, Tech Leads, Subproject Leads)
+        * Meeting schedules
+        * Contact information (Slack, mailing lists)
+        * Subprojects
+        * Charter link
+    * **All updates** to TAG and TOC Subproject information should be made in this file.
+
+2.  **README Generation with `readme_app.go`:**
+
+    * The `readme_app.go` program reads the data from `tags.yaml`.
+    * It uses Go templates (`tag_readme.tmpl` and `toc_subproject_readme.tmpl`) to format the data into README files.
+    * For each TAG and TOC Subproject defined in `tags.yaml`, the program generates a corresponding `README.md` file in the appropriate directory.
+    * It also generates a `charter.md` file if a charter link is provided in `tags.yaml`.
+
+3.  **Directory Structure**
+
+    * TAG README files are generated in the `tags/{tag.Dir}` directory.
+    * TOC Subproject README files are generated in the `toc_subprojects/{toc_subproject.Dir}` directory.
+
+## Workflow for Updating READMEs
+
+The process for updating README files is automated using a GitHub workflow, with slight differences depending on the source of the Pull Request (PR):
+
+1.  **Modify `tags.yaml`:** Make the necessary changes to the TAG or TOC Subproject entry in the `tags.yaml` file.
+2.  **Create a Pull Request (PR):** Submit a PR with your changes to the `tags.yaml` file.
+3.  **Automation Triggered:** The GitHub workflow is triggered by the PR. This workflow runs the `readme_app.go` program.
+4.  **READMEs Updated:** The program generates the updated README files.
+5.  **Handling PRs:**
+    * **PR from a Local Branch:** If the PR comes from a branch within the same repository, the automation will add a new commit to the PR, containing the updated README files.
+    * **PR from a Fork:** If the PR comes from a fork, the automation will create a *new* PR with the updated README files, and close the original PR.  The automation will also comment on both the original PR and the new PR to provide a link between them.
+6.  **Review and Merge:**
+    * **PR from a Local Branch:** Review the updated README files in the original PR. If everything is correct, merge the PR.
+    * **PR from a Fork:** Review the *new* PR created by the automation. If the changes are correct, merge the *new* PR.
+
+## `tags.yaml` Structure
+
+```yaml
+tags:
+  - dir: "tag-example"
+    name: "Example TAG"
+    mission_statement: "This is an example TAG."
+    leadership:
+      chairs:
+        - name: "Alex Johnson"
+          github: "alexjohnson"
+          company: "Example Corp" #optional
+      tech_leads:
+        - name: "Patrice Williams"
+          github: "patricewilliams"
+          company: "Another Corp"
+      subproject_leads: # Added subproject leads
+        - name: "Jordan Brown"
+          github: "jordanbrown"
+          company: "Some Company"
+    meetings:
+      - description: "TAG Meeting"
+        tag_calendar: "[https://example.com/calendar](https://example.com/calendar)"
+        recordings_url: "[https://example.com/recordings](https://example.com/recordings)"
+    contact:
+      slack: "#example-tag"
+      mailing_list: "tag-example@lists.cncf.io"
+      toc_liaison:
+        name: "TOC Person"
+        github: "tocperson"
+        company: "TOC"
+    tag_subprojects:
+      - name: "Example Subproject"
+        contact:
+          slack: "#example-subproject"
+          mailing_list: "subproject-example@lists.cncf.io"
+    charter_link: "[https://github.com/cncf/tag-example/blob/main/charter.md](https://github.com/cncf/tag-example/blob/main/charter.md)"
+toc_subprojects:
+  - dir: "toc-subproject-example"
+    name: "Example TOC Subproject"
+    mission_statement: "This is an example TOC Subproject."
+    leadership:
+      chairs:
+        - name: "Alex Johnson"
+          github: "alexjohnson"
+          company: "Example Corp"
+      tech_leads:
+        - name: "Patrice Williams"
+          github: "patricewilliams"
+          company: "Another Corp"
+      subproject_leads:
+        - name: "Jordan Brown"
+          github: "jordanbrown"
+          company: "Some Company"
+    meetings:
+      - description: "TOC Subproject Meeting"
+        tag_calendar: "[https://example.com/calendar](https://example.com/calendar)"
+        recordings_url: "[https://example.com/recordings](https://example.com/recordings)"
+    contact:
+      slack: "#toc-subproject-example"
+      mailing_list: "toc-subproject-example@lists.cncf.io"
+      toc_liaison:
+        name: "TOC Person"
+        github: "tocperson"
+        company: "TOC"
+    charter_link: "[https://github.com/cncf/toc-subproject-example/blob/main/charter.md](https://github.com/cncf/toc-subproject-example/blob/main/charter.md)"

--- a/generator/readme_app.go
+++ b/generator/readme_app.go
@@ -1,0 +1,182 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"text/template"
+
+	"gopkg.in/yaml.v2"
+)
+
+// Subproject struct to hold subproject data.
+type Subproject struct {
+	Name    string  `yaml:"name"`
+	Contact Contact `yaml:"contact"`
+}
+
+// Person struct to hold person data, including company.
+type Person struct {
+	Name    string `yaml:"name"`
+	GitHub  string `yaml:"github"`
+	Company string `yaml:"company,omitempty"`
+}
+
+// Leadership struct to hold all leadership roles.
+type Leadership struct {
+	Chairs          []Person `yaml:"chairs"`
+	TechLeads       []Person `yaml:"tech_leads"`
+	SubprojectLeads []Person `yaml:"Subpproject Leads"` // Corrected struct field name
+}
+
+// Meeting struct to hold meeting data.
+type Meeting struct {
+	Description   string `yaml:"description"`
+	RecordingsURL string `yaml:"recordings_url"`
+	TagCalendar   string `yaml:"tag_calendar,omitempty"`
+}
+
+// Contact struct to hold contact information.
+type Contact struct {
+	Slack       string `yaml:"slack"`
+	MailingList string `yaml:"mailing_list"`
+	TOCLiaison  Person `yaml:"toc_liaison"`
+}
+
+// Tag struct to hold tag data, including CharterLink and Subprojects.
+type Tag struct {
+	Dir              string       `yaml:"dir"`
+	Name             string       `yaml:"name"`
+	MissionStatement string       `yaml:"mission_statement"`
+	Leadership       Leadership   `yaml:"leadership"` // Use the Leadership struct defined above
+	Meetings         []Meeting    `yaml:"meetings"`
+	Contact          Contact      `yaml:"contact"`
+	TagSubprojects   []Subproject `yaml:"tag_subprojects"`
+	CharterLink      string       `yaml:"charter_link"`
+}
+
+// TOCSubproject struct to hold TOC subproject data, including CharterLink.
+type TOCSubproject struct {
+	Dir              string     `yaml:"dir"`
+	Name             string     `yaml:"name"`
+	MissionStatement string     `yaml:"mission_statement"`
+	Leadership       Leadership `yaml:"leadership"` // Use the Leadership struct
+	Meetings         []Meeting  `yaml:"meetings"`
+	Contact          Contact    `yaml:"contact"`
+	CharterLink      string     `yaml:"charter_link"`
+}
+
+// Config struct to hold the entire configuration.
+type Config struct {
+	Tags           []Tag           `yaml:"tags"`
+	TOCSubprojects []TOCSubproject `yaml:"toc_subprojects"`
+}
+
+func main() {
+	// Define paths.
+	configPath := filepath.Join("..", "tags.yaml")
+	tagsDir := filepath.Join("..", "tags")
+	tocDir := filepath.Join("..", "toc_subprojects")
+	tagTemplatePath := filepath.Join("..", "generator", "tag_readme.tmpl")
+	tocTemplatePath := filepath.Join("..", "generator", "toc_subproject_readme.tmpl")
+
+	// Read YAML file.
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		log.Fatalf("Failed to read tags.yaml: %v", err)
+	}
+
+	var config Config
+	if err := yaml.Unmarshal(data, &config); err != nil {
+		log.Fatalf("Failed to parse YAML: %v", err)
+	}
+
+	// Load templates.
+	tagTmplContent, err := os.ReadFile(tagTemplatePath)
+	if err != nil {
+		log.Fatalf("Failed to read tag template: %v", err)
+	}
+	tagTmpl, err := template.New("tag_readme").Parse(string(tagTmplContent))
+	if err != nil {
+		log.Fatalf("Failed to parse tag template: %v", err)
+	}
+
+	tocTmplContent, err := os.ReadFile(tocTemplatePath)
+	if err != nil {
+		log.Fatalf("Failed to read toc template: %v", err)
+	}
+	tocTmpl, err := template.New("toc_readme").Parse(string(tocTmplContent))
+	if err != nil {
+		log.Fatalf("Failed to parse toc template: %v", err)
+	}
+
+	// Ensure directories exist.
+	if err := ensureDir(tagsDir); err != nil {
+		log.Fatalf("Failed to create tags directory: %v", err)
+	}
+	if err := ensureDir(tocDir); err != nil {
+		log.Fatalf("Failed to create TOC Subprojects directory: %v", err)
+	}
+
+	// Process each tag.
+	for _, tag := range config.Tags {
+		tagFolderPath := filepath.Join(tagsDir, tag.Dir)
+		if err := ensureDir(tagFolderPath); err != nil {
+			log.Fatalf("Failed to create folder for tag %s: %v", tag.Name, err)
+		}
+
+		var tagBuf bytes.Buffer
+		if err := tagTmpl.Execute(&tagBuf, tag); err != nil {
+			log.Fatalf("Tag template execution failed: %v", err)
+		}
+
+		tagFilePath := filepath.Join(tagFolderPath, "README.md")
+		if err := os.WriteFile(tagFilePath, tagBuf.Bytes(), 0644); err != nil {
+			log.Fatalf("Failed to write %s: %v", tagFilePath, err)
+		}
+		// create charter.md
+		if tag.CharterLink != "" {
+			charterPath := filepath.Join(tagFolderPath, "charter.md")
+			if err := os.WriteFile(charterPath, []byte("Charter content here"), 0644); err != nil {
+				log.Fatalf("Failed to write %s: %v", charterPath, err)
+			}
+		}
+	}
+
+	// Process each TOC subproject.
+	for _, tocSubproject := range config.TOCSubprojects {
+		tocSubprojectFolderPath := filepath.Join(tocDir, tocSubproject.Dir)
+		if err := ensureDir(tocSubprojectFolderPath); err != nil {
+			log.Fatalf("Failed to create folder for TOC subproject %s: %v", tocSubproject.Name, err)
+		}
+
+		var tocBuf bytes.Buffer
+		if err := tocTmpl.Execute(&tocBuf, tocSubproject); err != nil {
+			log.Fatalf("TOC template execution failed: %v", err)
+		}
+
+		tocReadmePath := filepath.Join(tocSubprojectFolderPath, "README.md")
+		if err := os.WriteFile(tocReadmePath, tocBuf.Bytes(), 0644); err != nil {
+			log.Fatalf("Failed to write %s: %v", tocReadmePath, err)
+		}
+		//Create charter.md
+		if tocSubproject.CharterLink != "" {
+			charterPath := filepath.Join(tocSubprojectFolderPath, "charter.md")
+			if err := os.WriteFile(charterPath, []byte("Charter content here"), 0644); err != nil {
+				log.Fatalf("Failed to write %s: %v", charterPath, err)
+			}
+		}
+	}
+
+	log.Println("Tag, Subproject, and README files have been generated.")
+}
+
+// ensureDir ensures the directory exists.
+func ensureDir(dirPath string) error {
+	if err := os.MkdirAll(dirPath, 0755); err != nil {
+		return fmt.Errorf("failed to create directory %s: %v", dirPath, err)
+	}
+	return nil
+}

--- a/generator/tag_readme.tmpl
+++ b/generator/tag_readme.tmpl
@@ -1,0 +1,45 @@
+# {{.Name}}
+
+## Mission Statement
+{{.MissionStatement}}
+
+[Charter](./charter.md)
+
+## Leadership
+{{- if .Leadership.Chairs }}
+### Chairs
+{{- range .Leadership.Chairs }}
+- {{.Name}} (**[@{{.GitHub}}](https://github.com/{{.GitHub}})**){{if .Company}}, {{.Company}}{{end}}
+{{- end }}
+{{- end }}
+
+{{- if .Leadership.TechLeads }}
+### Tech Leads
+{{- range .Leadership.TechLeads }}
+- {{.Name}} (**[@{{.GitHub}}](https://github.com/{{.GitHub}})**){{if .Company}}, {{.Company}}{{end}}
+{{- end }}
+{{- end }}
+
+## Meetings
+{{- range .Meetings }}
+- **{{.Description}}**: 
+  {{- if .TagCalendar }} [Calendar]({{.TagCalendar}}) {{- end }}
+  {{- if .RecordingsURL }} | [Recordings]({{.RecordingsURL}}) {{- end }}
+{{- end }}
+
+## Contact
+- Slack: [#{{.Contact.Slack}}](https://slack.cncf.io/messages/{{.Contact.Slack}}})
+- [Mailing List]({{.Contact.MailingList}})
+- TOC Liaison: {{.Contact.TOCLiaison.Name}} (**[@{{.Contact.TOCLiaison.GitHub}}](https://github.com/{{.Contact.TOCLiaison.GitHub}})**)
+
+## Subprojects
+{{- range .TagSubprojects }}
+- **{{.Name}}**: [Mailing List]({{.Contact.MailingList}})
+{{- end }}
+
+{{- if .Leadership.SubprojectLeads }}
+### Subproject Leads
+{{- range .Leadership.SubprojectLeads }}
+- {{.Name}} (**[@{{.GitHub}}](https://github.com/{{.GitHub}})**){{if .Company}}, {{.Company}}{{end}}
+{{- end }}
+{{- end }}

--- a/generator/toc_subproject_readme.tmpl
+++ b/generator/toc_subproject_readme.tmpl
@@ -1,0 +1,40 @@
+# {{.Name}}
+
+## Mission Statement
+{{.MissionStatement}}
+
+[Charter](./charter.md)
+
+## Leadership
+{{- if .Leadership.Chairs }}
+### Chairs
+{{- range .Leadership.Chairs }}
+- {{.Name}} (**[@{{.GitHub}}](https://github.com/{{.GitHub}})**){{if .Company}}, {{.Company}}{{end}}
+{{- end }}
+{{- end }}
+
+{{- if .Leadership.TechLeads }}
+### Tech Leads
+{{- range .Leadership.TechLeads }}
+- {{.Name}} (**[@{{.GitHub}}](https://github.com/{{.GitHub}})**){{if .Company}}, {{.Company}}{{end}}
+{{- end }}
+{{- end }}
+
+## Meetings
+{{- range .Meetings }}
+- **{{.Description}}**: 
+  {{- if .TagCalendar }} [Calendar]({{.TagCalendar}}) {{- end }}
+  {{- if .RecordingsURL }} | [Recordings]({{.RecordingsURL}}) {{- end }}
+{{- end }}
+
+## Contact
+- Slack: [#{{.Contact.Slack}}](https://slack.cncf.io/messages/{{.Contact.Slack}})
+- [Mailing List]({{.Contact.MailingList}})
+- TOC Liaison: {{.Contact.TOCLiaison.Name}} (**[@{{.Contact.TOCLiaison.GitHub}}](https://github.com/{{.Contact.TOCLiaison.GitHub}})**)
+
+{{- if .Leadership.SubprojectLeads }}
+### Subproject Leads
+{{- range .Leadership.SubprojectLeads }}
+- {{.Name}} (**[@{{.GitHub}}](https://github.com/{{.GitHub}})**){{if .Company}}, {{.Company}}{{end}}
+{{- end }}
+{{- end }}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,14 @@
+module k8s.io/community
+
+go 1.22.4
+
+require (
+	github.com/client9/misspell v0.3.4
+	gopkg.in/yaml.v2 v2.4.0
+)
+
+require (
+	github.com/kr/text v0.2.0 // indirect
+	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
+	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,14 @@
+github.com/client9/misspell v0.3.4 h1:ta993UF76GwbvJcIo3Y68y/M3WxlpEHPWIGDkJYwzJI=
+github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
+github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
+github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
+github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
+github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
+github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f h1:BLraFXnmrev5lT+xlilqcH8XK9/i0At2xKjWk4p6zsU=
+gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=

--- a/tags.yaml
+++ b/tags.yaml
@@ -2,7 +2,7 @@ tags: # Technical Advisory Groups
   - dir: tag-developer-experience # TAG Developer Experience
     name: TAG Developer Experience
     mission_statement: >
-      Databases, Microservices, Streaming, Messaging, API Management, Dev Frameworks
+      Databases, Microservices, Streaming, Messaging, API Management, Dev Frameworks.
     charter_link: charter.md
     label: tag-developer-experience
     leadership:

--- a/tags.yaml
+++ b/tags.yaml
@@ -1,0 +1,378 @@
+tags: # Technical Advisory Groups
+  - dir: tag-developer-experience # TAG Developer Experience
+    name: TAG Developer Experience
+    mission_statement: >
+      Databases, Microservices, Streaming, Messaging, API Management, Dev Frameworks
+    charter_link: charter.md
+    label: tag-developer-experience
+    leadership:
+      chairs:
+        - github: foo
+          lfx_id: baz
+          name: Foo Baz Bar
+          company: Foo Baz Bar co
+          email: me@foobazbar.org
+        - github: foo
+          lfx_id: baz
+          name: Foo Baz Bar
+          company: Foo Baz Bar co.
+          email: me@foobazbar.org
+      tech_leads:
+        - github: foo
+          lfx_id: baz
+          name: Foo Baz Bar
+          company: Foo Baz Bar co.
+          email: me@foobazbar.org
+        - github: foo
+          lfx_id: baz
+          name: Foo Baz Bar
+          company: Foo Baz Bar co.
+          email: me@foobazbar.org
+    meetings:
+      - description: TAG Developer Experience Meetings
+        tag_calendar: https://zoom-lfx.platform.linuxfoundation.org/meetings/tag-developer-experience?view=list # Calendar from PCC
+        recordings_url: https://www.youtube.com/playlist?foo # to be updated
+    contact:
+      slack: cncf/tag-developer-experience # to be updated
+      mailing_list: https://lists.cncf.io/g/cncf-tag-TBA/messages
+      toc_liaison:
+        github: foobar
+        name: Foo Bar
+    tag_subprojects:
+      - name: Developer Experience-sub-foo
+        mission_statement: >
+          Foo-Baz_Bar
+        contact:
+          slack: tag-developer-experience # to be updated # Using parent TAG's contact
+          mailing_list: https://lists.cncf.io/g/cncf-tag-TBA/messages # to be updated # Using parent TAG's contact
+    leadership:
+      Subpproject Leads:
+        - github: foo
+          lfx_id: baz
+          name: Foo Baz Bar
+          company: Foo Baz Bar co.
+          email: me@foobazbar.org
+  - dir: tag-infrastructure # TAG Infrastructure
+    name: TAG Infrastructure
+    mission_statement: >
+      Data, Storage, Network, DNS, Compute, Service Mesh, Infrastructure-as-Code, Edge, Sovereignty, Load Balancing
+    charter_link: charter.md
+    label: tag-infrastructure
+    leadership:
+      chairs:
+        - github: foo
+          lfx_id: baz
+          name: Foo Baz Bar
+          company: Foo Baz Bar co.
+          email: me@foobazbar.org
+        - github: foo
+          lfx_id: baz
+          name: Foo Baz Bar
+          company: Foo Baz Bar co.
+          email: me@foobazbar.org
+      tech_leads:
+        - github: foo
+          lfx_id: baz
+          name: Foo Baz Bar
+          company: Foo Baz Bar co.
+          email: me@foobazbar.org
+        - github: foo
+          lfx_id: baz
+          name: Foo Baz Bar
+          company: Foo Baz Bar co.
+          email: me@foobazbar.org
+    meetings:
+      - description: TAG Infrastructure Meetings
+        tag_calendar: https://zoom-lfx.platform.linuxfoundation.org/meetings/tag-infrastructure?view=list
+        recordings_url: https://www.youtube.com/playlist?foo # to be updated
+    contact:
+      slack: tag-infrastructure
+      mailing_list: https://lists.cncf.io/g/cncf-tag-TBA/messages # to be updated
+      toc_liaison:
+        github: foobar
+        name: Foo Bar
+    tag_subprojects:
+      - name: Infrastructure-sub-foo
+        mission_statement: Foo-Baz_Bar
+        contact:
+          slack: tag-infrastructure # to be updated # Using parent TAG's contact
+          mailing_list: https://lists.cncf.io/g/cncf-tag-TBA/messages # to be updated # Using parent TAG's contact
+    leadership:
+      Subpproject Leads:
+        - github: foo
+          lfx_id: baz
+          name: Foo Baz Bar
+          company: Foo Baz Bar co.
+          email: me@foobazbar.org
+  - dir: tag-operational-resilience # TAG Operational Resilience
+    name: TAG Operational Resilience
+    mission_statement: >
+      Observability, Management, Business Continuity, Resource Optimization, Cost Efficiency, Energy, Performance, Troubleshooting, Reliability, Day 2 Ops
+    charter_link: charter.md
+    label: tag-operational-resilience
+    leadership:
+      chairs:
+        - github: foo
+          lfx_id: baz
+          name: Foo Baz Bar
+          company: Foo Baz Bar co.
+          email: me@foobazbar.org
+        - github: foo
+          lfx_id: baz
+          name: Foo Baz Bar
+          company: Foo Baz Bar co.
+          email: me@foobazbar.org
+      tech_leads:
+        - github: foo
+          lfx_id: baz
+          name: Foo Baz Bar
+          company: Foo Baz Bar co.
+          email: me@foobazbar.org
+        - github: foo
+          lfx_id: baz
+          name: Foo Baz Bar
+          company: Foo Baz Bar co.
+          email: me@foobazbar.org
+    meetings:
+      - description: TAG Operational Resilience Meetings
+        tag_calendar: https://zoom-lfx.platform.linuxfoundation.org/meetings/tag-operational-resilience?view=list # Calendar link from PCC
+        recordings_url: https://www.youtube.com/playlist?foo # to be updated
+    contact:
+      slack: cncf/tag-operational-resilience # to be updated
+      mailing_list: https://lists.cncf.io/g/cncf-tag-TBA/messages # to be updated
+      toc_liaison:
+        github: foobar
+        name: Foo Bar
+    tag_subprojects:
+      - name: Operational Resilience-sub-foo
+        mission_statement: >
+          Foo-Baz_Bar
+        contact:
+          slack: tag-operational-resilience # to be updated # Using parent TAG's contact
+          mailing_list: https://lists.cncf.io/g/cncf-tag-TBA/messages # to be updated # Using parent TAG's contact
+    leadership:
+      Subpproject Leads:
+        - github: foo
+          lfx_id: baz
+          name: Foo Baz Bar
+          company: Foo Baz Bar co.
+          email: me@foobazbar.org
+  - dir: tag-security-and-compliance # TAG Security and Compliance
+    name: TAG Security and Compliance
+    mission_statement: >
+      Security hygiene, Policy-as-code, Compliance, Auditing, Threat Modeling, Secure Software Supply Chain
+    charter_link: charter.md
+    label: tag-security-and-compliance
+    leadership:
+      chairs:
+        - github: foo
+          lfx_id: baz
+          name: Foo Baz Bar
+          company: Foo Baz Bar co.
+          email: me@foobazbar.org
+        - github: foo
+          lfx_id: baz
+          name: Foo Baz Bar
+          company: Foo Baz Bar co.
+          email: me@foobazbar.org
+      tech_leads:
+        - github: foo
+          lfx_id: baz
+          name: Foo Baz Bar
+          company: Foo Baz Bar co.
+          email: me@foobazbar.org
+        - github: foo
+          lfx_id: baz
+          name: Foo Baz Bar
+          company: Foo Baz Bar co.
+          email: me@foobazbar.org
+    meetings:
+      - description: TAG Security and Compliance Meetings
+        tag_calendar: https://zoom-lfx.platform.linuxfoundation.org/meetings/tag-security-and-compliance?view=list
+        recordings_url: https://www.youtube.com/playlist?foo # to be updated
+    contact:
+      slack: tag-security-and-compliance
+      mailing_list: https://lists.cncf.io/g/cncf-tag-TBA/messages # to be updated
+      toc_liaison:
+        github: foobar
+        name: Foo Bar
+    tag_subprojects:
+      - name: Security and Compliance-sub-foo
+        mission_statement: Foo-Baz_Bar
+        contact:
+          slack: tag-security-and-compliance # to be updated # Using parent TAG's contact
+          mailing_list: https://lists.cncf.io/g/cncf-tag-TBA/messages # to be updated # Using parent TAG's contact
+    leadership:
+      Subpproject Leads:
+        - github: foo
+          lfx_id: baz
+          name: Foo Baz Bar
+          company: Foo Baz Bar co.
+          email: me@foobazbar.org
+  - dir: tag-workloads-foundation # TAG Workloads Foundation
+    name: TAG Workloads Foundation
+    mission_statement: >
+      Containers, OS, Runtime, Virtual Machines, Serverless, Web Assembly, Batch, Scheduler, Orchestrator, Deployment, Dynamic Scaling, CI/CD
+    charter_link: charter.md
+    label: tag-workloads-foundation
+    leadership:
+      chairs:
+        - github: foo
+          lfx_id: baz
+          name: Foo Baz Bar
+          company: Foo Baz Bar co.
+          email: me@foobazbar.org
+        - github: foo
+          lfx_id: baz
+          name: Foo Baz Bar
+          company: Foo Baz Bar co.
+          email: me@foobazbar.org
+      tech_leads:
+        - github: foo
+          lfx_id: baz
+          name: Foo Baz Bar
+          company: Foo Baz Bar co.
+          email: me@foobazbar.org
+        - github: foo
+          lfx_id: baz
+          name: Foo Baz Bar
+          company: Foo Baz Bar co.
+          email: me@foobazbar.org
+    meetings:
+      - description: TAG Workloads Foundation Meetings
+        tag_calendar: https://zoom-lfx.platform.linuxfoundation.org/meetings/tag-workloads-foundation?view=list
+        recordings_url: https://www.youtube.com/playlist?foo # to be updated
+    contact:
+      slack: tag-workloads-foundation
+      mailing_list: https://lists.cncf.io/g/cncf-tag-TBA/messages # to be updated
+      toc_liaison:
+        github: foobar
+        name: Foo Bar
+    tag_subprojects:
+      - name: Workloads Foundation-sub-foo
+        mission_statement: Foo-Baz_Bar
+        contact:
+          slack: tag-workloads-foundation # to be updated # Using parent TAG's contact
+          mailing_list: https://lists.cncf.io/g/cncf-tag-TBA/messages # to be updated # Using parent TAG's contact
+    leadership:
+      Subpproject Leads:
+        - github: foo
+          lfx_id: baz
+          name: Foo Baz Bar
+          company: Foo Baz Bar co.
+          email: me@foobazbar.org
+toc_subprojects: # TOC Subprojects
+  - dir: contributor-strategy-subproject # Contributor Strategy Subproject
+    name: Contributor Strategy Subproject
+    mission_statement: Foo-Baz-Bar
+    charter_link: charter.md
+    label: contributor-strategy-subproject
+    leadership:
+      chairs:
+        - github: foo
+          lfx_id: baz
+          name: Foo Baz Bar
+          company: Foo Baz Bar co.
+          email: me@foobazbar.org
+        - github: foo
+          lfx_id: baz
+          name: Foo Baz Bar
+          company: Foo Baz Bar co.
+          email: me@foobazbar.org
+      tech_leads:
+        - github: foo
+          lfx_id: baz
+          name: Foo Baz Bar
+          company: Foo Baz Bar co.
+          email: me@foobazbar.org
+        - github: foo
+          lfx_id: baz
+          name: Foo Baz Bar
+          company: Foo Baz Bar co.
+          email: me@foobazbar.org
+    meetings:
+      - description: Contributor Strategy Subproject Meetings
+        tag_calendar: https://zoom-lfx.platform.linuxfoundation.org/meetings/toc-contributor-strategy-subproject?view=list
+        recordings_url: https://www.youtube.com/playlist?foo # to be updated
+    contact:
+      slack: contributor-strategy-subproject
+      mailing_list: https://lists.cncf.io/g/cncf-tag-TBA/messages # to be updated
+      toc_liaison:
+        github: foobar
+        name: Foo Bar
+  - dir: mentoring-subproject # Mentoring Subproject
+    name: Mentoring Subproject
+    mission_statement: Foo-Baz-Bar
+    charter_link: charter.md
+    label: mentoring-subproject
+    leadership:
+      chairs:
+        - github: foo
+          lfx_id: baz
+          name: Foo Baz Bar
+          company: Foo Baz Bar co.
+          email: me@foobazbar.org
+        - github: foo
+          lfx_id: baz
+          name: Foo Baz Bar
+          company: Foo Baz Bar co.
+          email: me@foobazbar.org
+      tech_leads:
+        - github: foo
+          lfx_id: baz
+          name: Foo Baz Bar
+          company: Foo Baz Bar co.
+          email: me@foobazbar.org
+        - github: foo
+          lfx_id: baz
+          name: Foo Baz Bar
+          company: Foo Baz Bar co.
+          email: me@foobazbar.org
+    meetings:
+      - description: Mentoring Subproject Meetings
+        tag_calendar: https://zoom-lfx.platform.linuxfoundation.org/meetings/toc-mentoring-subproject?view=list
+        recordings_url: https://www.youtube.com/playlist?foo # to be updated
+    contact:
+      slack: cncf/mentoring-subproject
+      mailing_list: https://lists.cncf.io/g/cncf-tag-TBA/messages # to be updated
+      toc_liaison:
+        github: foobar
+        name: Foo Bar
+  - dir: project-reviews-subproject # Project Reviews Subproject
+    name: Project Reviews Subproject
+    mission_statement: Foo-Baz-bar
+    charter_link: charter.md
+    label: project-reviews-subproject
+    leadership:
+      chairs:
+        - github: foo
+          lfx_id: baz
+          name: Foo Baz Bar
+          company: Foo Baz Bar co.
+          email: me@foobazbar.org
+        - github: foo
+          lfx_id: baz
+          name: Foo Baz Bar
+          company: Foo Baz Bar co.
+          email: me@foobazbar.org
+      tech_leads:
+        - github: foo
+          lfx_id: baz
+          name: Foo Baz Bar
+          company: Foo Baz Bar co.
+          email: me@foobazbar.org
+        - github: foo
+          lfx_id: baz
+          name: Foo Baz Bar
+          company: Foo Baz Bar co.
+          email: me@foobazbar.org
+    meetings:
+      - description: Project Reviews Subproject Meetings
+        tag_calendar: https://zoom-lfx.platform.linuxfoundation.org/meetings/toc-project-reviews-subproject?view=list
+        recordings_url: https://www.youtube.com/playlist?foo # to be updated
+    contact:
+      slack: project-reviews-subproject
+      mailing_list: https://lists.cncf.io/g/cncf-tag-TBA/messages # to be updated
+      toc_liaison:
+        github: foobar
+        name: Foo Bar

--- a/tags.yaml
+++ b/tags.yaml
@@ -34,7 +34,7 @@ tags: # Technical Advisory Groups
         recordings_url: https://www.youtube.com/playlist?foo # to be updated
     contact:
       slack: cncf/tag-developer-experience # to be updated
-      mailing_list: https://lists.cncf.io/g/cncf-tag-TBA/messages
+      mailing_list: https://lists.cncf.io/g/cncf-tag-developer-experience/
       toc_liaison:
         github: foobar
         name: Foo Bar
@@ -44,7 +44,7 @@ tags: # Technical Advisory Groups
           Foo-Baz_Bar
         contact:
           slack: tag-developer-experience # to be updated # Using parent TAG's contact
-          mailing_list: https://lists.cncf.io/g/cncf-tag-TBA/messages # to be updated # Using parent TAG's contact
+          mailing_list: https://lists.cncf.io/g/cncf-tag-developer-experience/ # Using parent TAG's contact
     leadership:
       Subpproject Leads:
         - github: foo
@@ -87,7 +87,7 @@ tags: # Technical Advisory Groups
         recordings_url: https://www.youtube.com/playlist?foo # to be updated
     contact:
       slack: tag-infrastructure
-      mailing_list: https://lists.cncf.io/g/cncf-tag-TBA/messages # to be updated
+      mailing_list: https://lists.cncf.io/g/cncf-tag-infrastructure
       toc_liaison:
         github: foobar
         name: Foo Bar
@@ -96,7 +96,7 @@ tags: # Technical Advisory Groups
         mission_statement: Foo-Baz_Bar
         contact:
           slack: tag-infrastructure # to be updated # Using parent TAG's contact
-          mailing_list: https://lists.cncf.io/g/cncf-tag-TBA/messages # to be updated # Using parent TAG's contact
+          mailing_list: https://lists.cncf.io/g/cncf-tag-infrastructure # Using parent TAG's contact
     leadership:
       Subpproject Leads:
         - github: foo
@@ -139,7 +139,7 @@ tags: # Technical Advisory Groups
         recordings_url: https://www.youtube.com/playlist?foo # to be updated
     contact:
       slack: cncf/tag-operational-resilience # to be updated
-      mailing_list: https://lists.cncf.io/g/cncf-tag-TBA/messages # to be updated
+      mailing_list: https://lists.cncf.io/g/cncf-tag-operational-resilience
       toc_liaison:
         github: foobar
         name: Foo Bar
@@ -149,7 +149,7 @@ tags: # Technical Advisory Groups
           Foo-Baz_Bar
         contact:
           slack: tag-operational-resilience # to be updated # Using parent TAG's contact
-          mailing_list: https://lists.cncf.io/g/cncf-tag-TBA/messages # to be updated # Using parent TAG's contact
+          mailing_list: https://lists.cncf.io/g/cncf-tag-operational-resilience # Using parent TAG's contact
     leadership:
       Subpproject Leads:
         - github: foo
@@ -192,7 +192,7 @@ tags: # Technical Advisory Groups
         recordings_url: https://www.youtube.com/playlist?foo # to be updated
     contact:
       slack: tag-security-and-compliance
-      mailing_list: https://lists.cncf.io/g/cncf-tag-TBA/messages # to be updated
+      mailing_list: https://lists.cncf.io/g/cncf-tag-security-and-compliance
       toc_liaison:
         github: foobar
         name: Foo Bar
@@ -201,7 +201,7 @@ tags: # Technical Advisory Groups
         mission_statement: Foo-Baz_Bar
         contact:
           slack: tag-security-and-compliance # to be updated # Using parent TAG's contact
-          mailing_list: https://lists.cncf.io/g/cncf-tag-TBA/messages # to be updated # Using parent TAG's contact
+          mailing_list: https://lists.cncf.io/g/cncf-tag-security-and-compliance # Using parent TAG's contact
     leadership:
       Subpproject Leads:
         - github: foo
@@ -244,7 +244,7 @@ tags: # Technical Advisory Groups
         recordings_url: https://www.youtube.com/playlist?foo # to be updated
     contact:
       slack: tag-workloads-foundation
-      mailing_list: https://lists.cncf.io/g/cncf-tag-TBA/messages # to be updated
+      mailing_list: https://lists.cncf.io/g/cncf-tag-workloads-foundation
       toc_liaison:
         github: foobar
         name: Foo Bar
@@ -253,7 +253,7 @@ tags: # Technical Advisory Groups
         mission_statement: Foo-Baz_Bar
         contact:
           slack: tag-workloads-foundation # to be updated # Using parent TAG's contact
-          mailing_list: https://lists.cncf.io/g/cncf-tag-TBA/messages # to be updated # Using parent TAG's contact
+          mailing_list: https://lists.cncf.io/g/cncf-tag-workloads-foundation # Using parent TAG's contact
     leadership:
       Subpproject Leads:
         - github: foo
@@ -296,7 +296,7 @@ toc_subprojects: # TOC Subprojects
         recordings_url: https://www.youtube.com/playlist?foo # to be updated
     contact:
       slack: contributor-strategy-subproject
-      mailing_list: https://lists.cncf.io/g/cncf-tag-TBA/messages # to be updated
+      mailing_list: https://lists.cncf.io/g/contributor-strategy-subproject
       toc_liaison:
         github: foobar
         name: Foo Bar
@@ -334,7 +334,7 @@ toc_subprojects: # TOC Subprojects
         recordings_url: https://www.youtube.com/playlist?foo # to be updated
     contact:
       slack: cncf/mentoring-subproject
-      mailing_list: https://lists.cncf.io/g/cncf-tag-TBA/messages # to be updated
+      mailing_list: https://lists.cncf.io/g/tag-cs-mentoring-wg # to be updated with new name post kubecon
       toc_liaison:
         github: foobar
         name: Foo Bar
@@ -372,7 +372,7 @@ toc_subprojects: # TOC Subprojects
         recordings_url: https://www.youtube.com/playlist?foo # to be updated
     contact:
       slack: project-reviews-subproject
-      mailing_list: https://lists.cncf.io/g/cncf-tag-TBA/messages # to be updated
+      mailing_list: https://lists.cncf.io/g/cncf-project-reviews-subproject
       toc_liaison:
         github: foobar
         name: Foo Bar

--- a/tags.yaml
+++ b/tags.yaml
@@ -33,7 +33,7 @@ tags: # Technical Advisory Groups
         tag_calendar: https://zoom-lfx.platform.linuxfoundation.org/meetings/tag-developer-experience?view=list # Calendar from PCC
         recordings_url: https://www.youtube.com/playlist?foo # to be updated
     contact:
-      slack: cncf/tag-developer-experience # to be updated
+      slack: https://cloud-native.slack.com/archives/C08KGCXB458
       mailing_list: https://lists.cncf.io/g/cncf-tag-developer-experience/
       toc_liaison:
         github: foobar
@@ -43,7 +43,7 @@ tags: # Technical Advisory Groups
         mission_statement: >
           Foo-Baz_Bar
         contact:
-          slack: tag-developer-experience # to be updated # Using parent TAG's contact
+          slack: https://cloud-native.slack.com/archives/C08KGCXB458 # Using parent TAG's contact
           mailing_list: https://lists.cncf.io/g/cncf-tag-developer-experience/ # Using parent TAG's contact
     leadership:
       Subpproject Leads:
@@ -86,7 +86,7 @@ tags: # Technical Advisory Groups
         tag_calendar: https://zoom-lfx.platform.linuxfoundation.org/meetings/tag-infrastructure?view=list
         recordings_url: https://www.youtube.com/playlist?foo # to be updated
     contact:
-      slack: tag-infrastructure
+      slack: https://cloud-native.slack.com/archives/C08KBH3RA1K
       mailing_list: https://lists.cncf.io/g/cncf-tag-infrastructure
       toc_liaison:
         github: foobar
@@ -95,7 +95,7 @@ tags: # Technical Advisory Groups
       - name: Infrastructure-sub-foo
         mission_statement: Foo-Baz_Bar
         contact:
-          slack: tag-infrastructure # to be updated # Using parent TAG's contact
+          slack: https://cloud-native.slack.com/archives/C08KBH3RA1K # Using parent TAG's contact
           mailing_list: https://lists.cncf.io/g/cncf-tag-infrastructure # Using parent TAG's contact
     leadership:
       Subpproject Leads:
@@ -138,7 +138,7 @@ tags: # Technical Advisory Groups
         tag_calendar: https://zoom-lfx.platform.linuxfoundation.org/meetings/tag-operational-resilience?view=list # Calendar link from PCC
         recordings_url: https://www.youtube.com/playlist?foo # to be updated
     contact:
-      slack: cncf/tag-operational-resilience # to be updated
+      slack: https://cloud-native.slack.com/archives/C08KGDENK34
       mailing_list: https://lists.cncf.io/g/cncf-tag-operational-resilience
       toc_liaison:
         github: foobar
@@ -148,7 +148,7 @@ tags: # Technical Advisory Groups
         mission_statement: >
           Foo-Baz_Bar
         contact:
-          slack: tag-operational-resilience # to be updated # Using parent TAG's contact
+          slack: https://cloud-native.slack.com/archives/C08KGDENK34 # Using parent TAG's contact
           mailing_list: https://lists.cncf.io/g/cncf-tag-operational-resilience # Using parent TAG's contact
     leadership:
       Subpproject Leads:
@@ -191,7 +191,7 @@ tags: # Technical Advisory Groups
         tag_calendar: https://zoom-lfx.platform.linuxfoundation.org/meetings/tag-security-and-compliance?view=list
         recordings_url: https://www.youtube.com/playlist?foo # to be updated
     contact:
-      slack: tag-security-and-compliance
+      slack: https://cloud-native.slack.com/archives/C08JZ9YLAA3
       mailing_list: https://lists.cncf.io/g/cncf-tag-security-and-compliance
       toc_liaison:
         github: foobar
@@ -200,7 +200,7 @@ tags: # Technical Advisory Groups
       - name: Security and Compliance-sub-foo
         mission_statement: Foo-Baz_Bar
         contact:
-          slack: tag-security-and-compliance # to be updated # Using parent TAG's contact
+          slack: https://cloud-native.slack.com/archives/C08JZ9YLAA3 # Using parent TAG's contact
           mailing_list: https://lists.cncf.io/g/cncf-tag-security-and-compliance # Using parent TAG's contact
     leadership:
       Subpproject Leads:
@@ -243,7 +243,7 @@ tags: # Technical Advisory Groups
         tag_calendar: https://zoom-lfx.platform.linuxfoundation.org/meetings/tag-workloads-foundation?view=list
         recordings_url: https://www.youtube.com/playlist?foo # to be updated
     contact:
-      slack: tag-workloads-foundation
+      slack: https://cloud-native.slack.com/archives/C08K71W9HAS
       mailing_list: https://lists.cncf.io/g/cncf-tag-workloads-foundation
       toc_liaison:
         github: foobar
@@ -252,7 +252,7 @@ tags: # Technical Advisory Groups
       - name: Workloads Foundation-sub-foo
         mission_statement: Foo-Baz_Bar
         contact:
-          slack: tag-workloads-foundation # to be updated # Using parent TAG's contact
+          slack: https://cloud-native.slack.com/archives/C08K71W9HAS # Using parent TAG's contact
           mailing_list: https://lists.cncf.io/g/cncf-tag-workloads-foundation # Using parent TAG's contact
     leadership:
       Subpproject Leads:
@@ -295,7 +295,7 @@ toc_subprojects: # TOC Subprojects
         tag_calendar: https://zoom-lfx.platform.linuxfoundation.org/meetings/toc-contributor-strategy-subproject?view=list
         recordings_url: https://www.youtube.com/playlist?foo # to be updated
     contact:
-      slack: contributor-strategy-subproject
+      slack: https://cloud-native.slack.com/archives/C08KGDKKHMY
       mailing_list: https://lists.cncf.io/g/contributor-strategy-subproject
       toc_liaison:
         github: foobar
@@ -333,7 +333,7 @@ toc_subprojects: # TOC Subprojects
         tag_calendar: https://zoom-lfx.platform.linuxfoundation.org/meetings/toc-mentoring-subproject?view=list
         recordings_url: https://www.youtube.com/playlist?foo # to be updated
     contact:
-      slack: cncf/mentoring-subproject
+      slack: https://cloud-native.slack.com/archives/CGPK98JNQ
       mailing_list: https://lists.cncf.io/g/tag-cs-mentoring-wg # to be updated with new name post kubecon
       toc_liaison:
         github: foobar
@@ -371,7 +371,7 @@ toc_subprojects: # TOC Subprojects
         tag_calendar: https://zoom-lfx.platform.linuxfoundation.org/meetings/toc-project-reviews-subproject?view=list
         recordings_url: https://www.youtube.com/playlist?foo # to be updated
     contact:
-      slack: project-reviews-subproject
+      slack: https://cloud-native.slack.com/archives/C08KBHCQDPF
       mailing_list: https://lists.cncf.io/g/cncf-project-reviews-subproject
       toc_liaison:
         github: foobar


### PR DESCRIPTION
Automates the generation of README files for Technical Advisory Groups (TAGs) and TOC Subprojects. 
The README files are populated with data from the `tags.yaml` file.