### PR TITLE
Update gitvote voters to use cncf-toc-voters

### DIFF
--- a/.gitvote.yml
+++ b/.gitvote.yml
@@ -5,7 +5,7 @@ profiles:
     periodic_status_check: "1 week"
     allowed_voters:
       teams:
-        - cncf-toc
+        - cncf-toc-voters
       exclude_team_maintainers: true
     close_on_passing: true
     announcements:
@@ -16,6 +16,7 @@ profiles:
     pass_threshold: 66
     allowed_voters:
       teams:
-        - cncf-toc
+        - cncf-toc-voters
       exclude_team_maintainers: true
     close_on_passing: true
+


### PR DESCRIPTION
Changes the voter group to `cncf-toc-voters`
As the shadows are included in the `cncf-toc` group it should no longer be used for voting.

The file was also "windows" format with the windows newline character at the end. I changed it to unix.