### PR TITLE
Update meeting agenda and minutes links in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,10 +71,10 @@ Here is a [Google calendar for all public CNCF events](https://goo.gl/eyutah). T
 
 
 ## Meeting Agenda and Minutes
-
-- [Meeting Working Doc](https://docs.google.com/document/d/1jpoKT12jf2jTf-2EJSAl4iTdA7Aoj_uiI19qIaECNFc/edit#). This includes minutes from previous meetings.
-- [Meeting agenda and presentations](docs/meeting_presentations.md).
-- [Archive of community presentations](docs/scheduled_presentations.md)
+- [Meeting Agenda and Minutes](https://github.com/cncf/toc/issues?q=is%3Aissue%20label%3Akind%2Fmeeting%20)
+- [Archive (2018.10~2024.08) of Meeting Working Doc](https://docs.google.com/document/d/1jpoKT12jf2jTf-2EJSAl4iTdA7Aoj_uiI19qIaECNFc/edit#). This includes minutes from previous meetings.
+- [Archive (2016.02~2019.06) of Meeting agenda and presentations](resources/meeting_presentations.md).
+- [Archive (2016.04~2018.11) of community presentations](resources/scheduled_presentations.md)
 - [CNCF TOC Playlist on YouTube](https://www.youtube.com/playlist?list=PLj6h78yzYM2Mf6GCZzW6CAk6GlZESbemB)
 
 ## Mailing List


### PR DESCRIPTION
This PR fixes the meeting minutes links to reflect the following updates:

1. We have moved to github for meeting agenda and minutes for a while, all the latest info can be found at <https://github.com/cncf/toc/issues?q=is%3Aissue%20label%3Akind%2Fmeeting%20>
2. The archives, `meeting_presentations.md`, `scheduled_presentations.md` have been moved from `/docs` to `/resources`
