### PR TITLE
Add TAG Security and Compliance charter

### DIFF
--- a/tags/tag-security-and-compliance/charter.md
+++ b/tags/tag-security-and-compliance/charter.md
@@ -1,1 +1,50 @@
-Charter content here
+# CNCF TAG Security and Compliance Charter
+
+## Mission
+
+TAG Security and Compliance exists to assist the Technical Oversight Committee in delivering on the CNCF’s technical vision of secure, cloud native systems. The TAG supports the TOC’s project work by reviewing incoming projects and supporting existing projects through guidance and adoption of sound principles to achieve cybersecurity and compliance readiness. Alongside this work, the TAG also produces supporting content for end users to enable the adoption of CNCF projects.
+
+## In Scope
+
+The TAG may establish subprojects, initiatives, or events related to cloud native security and compliance including, but not limited to, the following:
+
+* Supporting TOC domain technical reviews through security assessments
+* Proposing project security standards, policies, or tooling
+* Providing guidance on how to conform to requirements of relevant regulatory frameworks (i.e. EU’s Cyber Resilience Act) for CNCF-hosted projects and installations thereof
+* Increasing project knowledge of security best practices
+* Supporting project maintainers before, during, and after third-party audits
+* Providing a global view of security and compliance trends across CNCF projects and the larger industry.
+* Adapting existing outputs from other organizations (like the OpenSSF) to a cloud-native context
+
+## Out of Scope
+
+* Software intended for adoption beyond the TAG. Software projects, including those that stem from TAG initiatives, should apply to the CNCF through the projects process.
+* Standards or recommendations that are not intended for adoption within the CNCF or by end-users of CNCF projects.
+* Kubernetes-related [topics covered](https://github.com/kubernetes/community/blob/master/sig-security/charter.md) by Kubernetes SIG Security
+
+## Success Criteria
+
+* Effective establishment, operation, and completion of Subprojects and Initiatives.
+* Creation and dissemination of timely and effective knowledge resources, as measured by user satisfaction
+* Projects which engage with the TAG report usefulness or see measurable improvements in project security (as measured by time to complete security-related graduation requirements, security scorecards, or reported vulnerabilities)
+* Positive feedback from community stakeholders on the value of TAG produced work products
+* Recruiting new leadership and community members to support, drive, and deliver work within the TAG’s scope.
+
+## Coordination
+
+The TAG Security and Compliance will coordinate with various stakeholders within the CNCF and LF ecosystems, such as:
+
+* **CNCF Projects**: The TAG provides services to projects, such as security guidance and security assessments, and its work helps align projects within the CNCF ecosystem through defining best practices and providing a global view of security. This coordination ensures alignment across the foundation and provides pathways for community focuses to be supported
+* **Other TAGs**: Coordination is essential as TAGs serve needs across projects and other TAGs.
+* **OpenSSF**: The OpenSSF focuses on securing the development, maintenance, release, and consumption of open source software.  As peer LF foundation, they provide guidance and best practices which may be recommended by the TAG.
+* Projects with substantial overlap or impact on this TAG’s mandate may be done in coordination with outside groups such as the OpenSSF, other TAGs, and others.
+* **TOC Subprojects**: TAG leadership participates in TOC Subprojects like Project Reviews and Contributor Strategy.
+* **Community Groups**: Community Groups are encouraged to discuss initiative ideas and may submit applications for initiatives within a TAG.
+
+The TAG Security and Compliance will coordinate with various stakeholders outside the CNCF and LF ecosystems, such as:
+
+* **Standards Bodies**: Coordination as is appropriate to ensure the development and dissemination of secure practices across the cloud native ecosystem.
+
+## Alignment with the CNCF TOC Charter
+
+The TAG Security and Compliance charter is directly aligned with the CNCF TOC charter. The TOC is the technical governing body responsible for maintaining the technical vision and driving common practices across projects. The TOC's vision is problem-centric, encouraging projects to solve challenges faced by adopters. By focusing on critical areas like security hygiene, compliance, threat modeling, and the secure software supply chain, the TAG Security and Compliance directly addresses significant problems faced by cloud native adopters and projects in ensuring that trustworthy and accurate security guidance is available to projects and adopters. The TAG's work in defining practices, conducting assessments (as shown in example Subprojects and Initiatives), and potentially creating guidelines contributes to driving common practices across the ecosystem. The TAG's work in defining best practices, frameworks, and performing assessments contributes to driving common practices and aligning projects within the ecosystem, which supports the mission of the TOC.


### PR DESCRIPTION
Add a draft charter from the leads and chairs of TAG SC.

cc @eddie-knight @evankanderson @JustinCappos @y-tabata @brandtkeller @jpower432 @mlieberman85 @jkjell 