### PR TITLE
Fix labeler workflow config

### DIFF
--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -32,7 +32,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          labels: ./.github/labels.yaml
+          labels: https://raw.githubusercontent.com/cncf/toc/refs/heads/main/.github/labels.yaml
           owner: ${{ github.repository_owner }}
           repo: ${{ github.event.repository.name }}
           issue_number: ${{ github.event.pull_request.number }}
@@ -45,7 +45,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          labels: ./.github/labels.yaml
+          labels: https://raw.githubusercontent.com/cncf/toc/refs/heads/main/.github/labels.yaml
           owner: ${{ github.repository_owner }}
           repo: ${{ github.event.repository.name }}
           issue_number: ${{ github.event.issue.number }}


### PR DESCRIPTION
Fixes the broken workflow by updating the label config path to use a url instead of filepath