### PR TITLE
Migrate Knative review from tag-contributor-strategy repo

### DIFF
--- a/projects/knative/governance-review/2025-05-29.md
+++ b/projects/knative/governance-review/2025-05-29.md
@@ -1,0 +1,173 @@
+# Knative Governance Review for Graduation
+
+What follows is a governance review and assessment for the Knative project. This review is carried out by members of the Governance Working Group of TAG Contributor Strategy. The review may have been done because of a change in maturity level for the project, at the request of the TOC, or as a request by the project itself. If requested by the project, the review will be provided to the project maintainers. Otherwise, the review will be submitted to the TOC for their follow-up.  
+Projects may ask TAG Contributor Strategy for assistance in resolving any issues uncovered by the review. The TAG is available via our [slack channel](https://cloud-native.slack.com/archives/CT6CWS1JN), [email](https://lists.cncf.io/g/cncf-tag-contributor-strategy), [GitHub](https://github.com/cncf/tag-contributor-strategy), or by joining our weekly meetings (listed on the [CNCF public calendar](https://www.cncf.io/calendar/)).
+
+## Summary and Assessment
+
+Status: Exemplary
+
+### Executing the Assessment
+
+#### Must-Fix Items
+
+No issues have been identified that need to be resolved before graduation:
+
+#### Points of Excellence
+
+The following aspects of governance are exemplary, and can be referenced as examples for other projects to copy:
+
+* **Contributor ladder:** Knative has excellent documentation for getting started contributing, entering from either the knative.dev website or GitHub project. The documentation is up-to-date, well organized into a few documents and consistent across the different working groups. After 12 months contributing, an individual is eligible to vote. The project conveys a sense of openness to accept new contributors and help them move up the ladder.   
+* **Responsiveness and evolution:** The reviewer found the project team to be responsive. A security escalation had a first-response in less than an hour; a governance suggestion was accepted by the project team, who demonstrated a willingness to listen to new ideas. This responsiveness leads to evolution and improvements in processes. Knative is a mature project, but a new user has the sense that they can still make a difference.    
+* **Transparency and community:** Across the project working groups, there were 32 community meetings in May 2025. Managing community meetings at scale is a huge commitment, continuing this commitment year-after-year is an impressive achievement. The project records meetings, meeting notes, changes in governance, and keeps governance documents well-organized and up-to-date.   
+* **Community sub-project:** Knative maintains its documents in a dedicated Community sub-project. This convention is recommended for all CNCF projects; helping the project team maintain project documentation, and making it simpler for casual users to find project documentation. 
+
+#### Areas for Improvement
+
+Over the next year, the project should work on the following issues to improve its governance, these are considered non-blocking:
+
+* Knative to determine and document the process for removing a Steering Committee Member (see [issue 1688](https://github.com/knative/community/pull/1688))
+
+## Review
+
+The following review primarily consists of an audit on the project's self-assessment for Graduation.
+
+### Governance Summary
+
+**Summary:**   
+Project governance is managed by the Knative steering committee (KSC), who delegate technical work to working groups. Anyone can contribute by joining a working group, and after a period of activity (25 interactions in 12 months), a contributor is eligible to participate in both steering group committee elections, and to stand for election to the KSC. There are written guidelines for the ladder from contributor-to-KSC, how elections are run, and processes to ensure limitations on company representation. There are provisions to ensure KSC can select additional members to meet expertise requirements. A KSC member term is two years. At the time of writing, there are no formal processes for removing a non-performing KSC member during their term, this is being addressed in [PR 1688](https://github.com/knative/community/pull/1688).
+
+**References:**
+
+* Knative governance is based on the [Steering Committee](https://contribute.cncf.io/maintainers/templates/governance-elections/) governance model  
+* [Becoming a new contributor](https://github.com/knative/community/blob/main/CONTRIBUTING.md), and the [ladder to move into leadership positions](https://github.com/knative/community/blob/main/ROLES.md)  
+* [KSC members and processes](https://github.com/knative/community/blob/main/STEERING-COMMITTEE.md)  
+* [KSC composition guidelines](https://github.com/knative/community/blob/main/STEERING-COMMITTEE.md#composition) 
+
+### Governance Evolution
+
+**Summary:**  
+Governance has evolved. Previously there was a technical oversight committee, which has since been merged into the KSC. This change is clearly documented, the retired technical oversight committee document still exists, and references the change. Emeritus members of the technical oversight committee are credited. Changes to the charter are documented in the Steering Committee document. The evolution in governance is transparent to anyone reading Knative documentation  
+   
+**References:**
+
+* [Changes to the charter](https://github.com/knative/community/blob/main/STEERING-COMMITTEE.md#changes-to-the-charter)  
+* [Technical oversight committee](https://github.com/knative/community/blob/main/TECH-OVERSIGHT-COMMITTEE.md) document
+
+### Discoverability
+
+**Summary:**  
+The governance documents are easily discoverable, from either the Knative website community section, or the Knative GitHub project. All governance and community documents are stored in a GitHub Community sub-project. The documents are easy to find, easy-to-read, and reference related documents. The project has clearly put effort into transparently documenting its governance.
+
+**References:**
+
+* Knative website [community section](https://knative.dev/docs/community/)  
+* Knative Community [GitHub sub-project](https://github.com/knative/community/)  
+* [Processes roll-up page](https://knative.dev/docs/community/governance/#processes) on Knative website
+
+### Accuracy and Clarity
+
+**Summary:**  
+The Knative governance activities are up-to-date. The community calendar displays a rich set of recent and upcoming events. The release schedule shows a record of regular product releases and planned releases. KSC elections are documented. KSC meeting notes are publicly available and show regular and productive meetings. Vendor neutrality is embedded into the Steering Committee document. The security escalation email address is actively maintained, with a person responding in 12 minutes. 
+
+**References:**
+
+* [Community calendar](https://knative.dev/docs/community/governance/#community-calendar) on knative.dev  
+* [Release schedule](https://github.com/knative/community/blob/main/mechanics/RELEASE-SCHEDULE.md) from community GitHub sub-project  
+* [Elections folder](https://github.com/knative/community/tree/main/elections) from community GitHub sub-project  
+* [KSC meeting notes](https://docs.google.com/document/d/16Rpd2nhmLWrkFJUfpJ31Ox2PpultJ-bYIhqaiWQff_I/edit?tab=t.0#heading=h.jlesqjgc1ij3)  
+* [Limitations on company representation](https://github.com/knative/community/blob/main/STEERING-COMMITTEE.md#limitations-on-company-representation) section of Steering Committee document, demonstrating a commitment to vendor neutrality 
+
+**Inaccurate content**
+
+* Reviewer found an issue on Knative Website, Processes section: [TOC Election Process](https://github.com/knative/community/blob/main/mechanics/TOC.md) link 404’s. Project team has addressed this issue  (see [PR 1687](https://github.com/knative/community/pull/1687))
+
+### Decisions and Role Assignments
+
+**Summary:**  
+The KSC sets direction, and delegates roadmap to working groups. There are eight working groups (Serving, Client, User Experience, Eventing, Functions, Operations, Productivity, Security). For each working group; membership, meeting schedule, meeting notes, roadmap are documented (although some of the documents are private to members). The contributor ladder works as follows: Anyone can contribute and there is documentation for getting started and for contributing a non-trivial feature. There is a documented ladder from Contributor to Member to Approver to Working Group Lead; and a documented process to stand for election to the KSC.  
+
+**References:**
+
+* [Governance](https://github.com/knative/community/blob/main/GOVERNANCE.md) document from GitHub Community sub-project  
+* [Working Groups](https://github.com/knative/community/blob/main/working-groups/WORKING-GROUPS.md) document from GitHub Community sub-project  
+* [Contributing](https://github.com/knative/community/blob/main/CONTRIBUTING.md) document from GitHub Community sub-project  
+* [Contributing](https://knative.dev/docs/community/contributing/) page from Knative website  
+* [Setting up a development environment](https://github.com/knative/serving/blob/main/DEVELOPMENT.md) from GitHub community sub-project  
+* [Feature track](https://github.com/knative/community/blob/main/mechanics/FEATURE-TRACKS.md) document from GitHub Community sub-project  
+* [Contributor ladder](https://github.com/knative/community/blob/main/ROLES.md) document from GitHub Community sub-project
+
+### Maintainers and Maintainer Lifecycle
+
+**Summary:**  
+The list of maintainers (Steering Committee) and their company affiliation are clearly documented. The KSC has between 5-7 members, and no more than two seats can have the same company affiliation. The process for electing a maintainer is clearly documented. Maintainer election records are public. Maintainer meeting records are publicly documented. Processes for resolving decision deadlock, requirements for remaining a maintainer, process for removing a maintainer are not documented.
+
+As at May 2025, there are 5 maintainers: 
+| Name | Company Affiliation |
+| :------------ | :------------ |
+| Ali OK  | Red Hat  |
+| Evan Anderson  | Slacklok    |
+| Norris Sam Osarenkhoe | SVA (end user seat) |
+| Dave Protasowski | Independent |
+| Matthias Wessendorf | Red Hat |
+
+**References:**
+
+* [Steering committee](https://github.com/knative/community/blob/main/STEERING-COMMITTEE.md#committee-members) document from GitHub Community sub-project  
+* [Elections folder](https://github.com/knative/community/tree/main/elections) from GitHub Community sub-project  
+* [KSC meeting notes](https://docs.google.com/document/d/16Rpd2nhmLWrkFJUfpJ31Ox2PpultJ-bYIhqaiWQff_I/edit?tab=t.0#heading=h.jlesqjgc1ij3)
+
+### Ownership
+
+**Summary:**  
+Knative uses Peribolos for GitHub group membership, and Prow for PR approval mechanisms. The KSC is both reviewer and approver for all projects. 
+
+**References:**
+
+* [Ownership document](https://github.com/knative/community/blob/main/mechanics/OWNERS) from GitHub Community sub-project
+
+### Code of Conduct
+
+**Summary:**  
+The project follows the CNCF code of conduct. The project documents escalating issues to the KSC, with another escalation point to CNCF.  
+**References:**
+
+* [Code of conduct](https://github.com/knative/community/blob/main/CODE-OF-CONDUCT.md) document from GitHub Community sub-project
+
+### Sub-projects
+
+**Summary:**  
+Knative has eight sub-projects, each run by a working group with its own roadmap, community meetings, repos and Slack channels. The sub-projects are owned by the Knative parent project, and the working groups adhere to the parent project governance, code of conduct, ownership, shared-values and other processes. The working groups and sub-projects have their own lifecycle, the KSC is active in moving a working group to emeritus status,  if it is no longer actively worked on.
+
+**The eight sub-projects / working groups are:**
+
+| Sub project (working group) | Ownership and operation | Communications | Project alignment | Notes |
+| :---- | :---- | :---- | :---- | :---- |
+| [Serving](https://github.com/knative/community/blob/main/working-groups/WORKING-GROUPS.md#serving) | Complete | Complete | Complete | Meeting notes are private and could not be reviewed. |
+| [Client](https://github.com/knative/community/blob/main/working-groups/WORKING-GROUPS.md#client) | Complete | Complete | Complete | Meeting notes are private and could not be reviewed. |
+| [User Experience](https://github.com/knative/community/blob/main/working-groups/WORKING-GROUPS.md#user-experience) | Complete | Complete | Complete |  |
+| [Eventing](https://github.com/knative/community/blob/main/working-groups/WORKING-GROUPS.md#eventing) | Complete | Complete | Complete |  |
+| [Functions](https://github.com/knative/community/blob/main/working-groups/WORKING-GROUPS.md#functions) | Complete | Complete | Complete |  |
+| [Operations](https://github.com/knative/community/blob/main/working-groups/WORKING-GROUPS.md#operations) | Complete | Complete | Complete | Meeting notes are private and could not be reviewed. |
+| [Productivity](https://github.com/knative/community/blob/main/working-groups/WORKING-GROUPS.md#productivity) | Complete | Complete | Complete | Meeting notes are private and could not be reviewed. |
+| [Security](https://github.com/knative/community/blob/main/working-groups/WORKING-GROUPS.md#security) | Complete | Complete | Complete | Meeting notes are private and could not be reviewed. |
+
+**References:**
+
+* [Working Groups](https://github.com/knative/community/blob/main/working-groups/WORKING-GROUPS.md)  
+* [Emeritus Working Groups](https://github.com/knative/community/blob/main/working-groups/WORKING-GROUPS.md#emeritus-working-groups)
+
+### Contributors and Community
+
+**Summary:**   
+Knative has a contributor ladder with multiple roles: contributor \-\> member \-\> approver \-\> working group lead. Each sub-project (working group) has a standard set of communication channels for users/contributors: Google mailing list, community meeting, Slack channel. There is a clearly defined and discoverable process to get started, submit issues or changes, for each working group. The contact info for working group leads is clearly documented. The Knative website has a roll-up calendar that displays community meetings across all working groups.
+
+Knative has an active community, [16,684 contributions from 83 companies](https://knative.devstats.cncf.io/d/5/companies-table?orgId=1&var-period_name=Last%20year&var-metric=contributions) in the last year, including [67 new contributors](https://knative.devstats.cncf.io/d/52/new-contributors-table?orgId=1&from=now-1y&to=now).
+
+**References:**
+
+* [Contributing guidelines](https://knative.dev/docs/community/contributing/) page on Knative.dev website  
+* [How the Knative community is run](https://knative.dev/docs/community/governance/) page on Knative website  
+* [Contributing](https://github.com/knative/community/blob/main/CONTRIBUTING.md) document from GitHub community sub-project  
+* [Community meeting roll-up calendar](https://knative.dev/docs/community/#meetings) page on Knative website  
+* [Knative devstats](https://knative.devstats.cncf.io/explore?orgId=1&left=%7B%22datasource%22:%22psql%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22format%22:%22time_series%22,%22timeColumn%22:%22created_at%22,%22metricColumn%22:%22none%22,%22group%22:%5B%5D,%22where%22:%5B%7B%22type%22:%22macro%22,%22name%22:%22$__timeFilter%22,%22params%22:%5B%5D%7D%5D,%22select%22:%5B%5B%7B%22type%22:%22column%22,%22params%22:%5B%22license_prob%22%5D%7D%5D%5D,%22rawQuery%22:false,%22rawSql%22:%22SELECT%5Cn%20%20created_at%20AS%20%5C%22time%5C%22,%5Cn%20%20license_prob%5CnFROM%20gha_repos%5CnWHERE%5Cn%20%20$__timeFilter\(created_at\)%5CnORDER%20BY%201%22,%22table%22:%22gha_repos%22,%22timeColumnType%22:%22timestamp%22%7D%5D,%22range%22:%7B%22from%22:%22now-1h%22,%22to%22:%22now%22%7D%7D&search=open) page


### PR DESCRIPTION
#1602 copied existing governance reviews into the TOC repo.  Unfortunately, https://github.com/cncf/tag-contributor-strategy/pull/811 created a new governance review in the old repo.  Migrating it as well.

