### PR TITLE
Update README generator to fix charter overwrite and incorrect links

### DIFF
--- a/.github/workflows/tags_yaml_branch_pr_processing.yaml
+++ b/.github/workflows/tags_yaml_branch_pr_processing.yaml
@@ -53,7 +53,7 @@ jobs:
         run: |
           git add .
           if [ -n "$(git status --porcelain)" ]; then
-            git commit -m "Update README based on tags.yaml changes"
+            git commit -sm "Update README based on tags.yaml changes"
             git push origin HEAD:${{ github.event.pull_request.head.ref }}
           else
             echo "No changes to commit"

--- a/.github/workflows/tags_yaml_fork_pr_processing.yaml
+++ b/.github/workflows/tags_yaml_fork_pr_processing.yaml
@@ -62,7 +62,7 @@ jobs:
           git config --global user.email "github-actions@github.com"
           git add .
           if ! git diff --staged --quiet; then
-            git commit -m "Update README based on tags.yaml changes"
+            git commit -sm "Update README based on tags.yaml changes"
             git push origin $BRANCH_NAME --force
             PR_TITLE="Update README based on tags.yaml changes from fork PR #${{ github.event.pull_request.number }}"
             PR_BODY="This PR updates the README file based on changes in tags.yaml from fork PR #${{ github.event.pull_request.number }}."

--- a/generator/readme_app.go
+++ b/generator/readme_app.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strings"
 	"text/template"
 
 	"gopkg.in/yaml.v2"
@@ -61,20 +62,24 @@ type Tag struct {
 	Meetings         []Meeting    `yaml:"meetings"`
 	Contact          Contact      `yaml:"contact"`
 	TagSubprojects   []Subproject `yaml:"tag_subprojects"`
-	CharterLink      string       `yaml:"charter_link"`
-	TagInitiatives   string       `yaml:"tag_initiatives"`
+	// The following are all generated, and the fields in the YAML file are ignored.
+	CharterLink    string `yaml:"charter_link"`
+	TagLabel       string `yaml:"tag_label"`
+	TagInitiatives string `yaml:"tag_initiatives"`
 }
 
 // TOCSubproject struct to hold TOC subproject data, including CharterLink.
 type TOCSubproject struct {
-	Dir                   string     `yaml:"dir"`
-	Name                  string     `yaml:"name"`
-	MissionStatement      string     `yaml:"mission_statement"`
-	Leadership            Leadership `yaml:"leadership"`
-	Meetings              []Meeting  `yaml:"meetings"`
-	Contact               Contact    `yaml:"contact"`
-	CharterLink           string     `yaml:"charter_link"`
-	SubprojectInitiatives string     `yaml:"subproject_initiatives"`
+	Dir              string     `yaml:"dir"`
+	Name             string     `yaml:"name"`
+	MissionStatement string     `yaml:"mission_statement"`
+	Leadership       Leadership `yaml:"leadership"`
+	Meetings         []Meeting  `yaml:"meetings"`
+	Contact          Contact    `yaml:"contact"`
+	// The following are all generated, and the fields in the YAML file are ignored.
+	CharterLink           string `yaml:"charter_link"`
+	SubprojectInitiatives string `yaml:"subproject_initiatives"`
+	SubprojectLabel       string `yaml:"subproject_label"`
 }
 
 // Config struct to hold the entire configuration.
@@ -136,21 +141,27 @@ func main() {
 			log.Fatalf("Failed to create folder for tag %s: %v", tag.Name, err)
 		}
 
+		charterPath := filepath.Join(tagFolderPath, "charter.md")
+		if _, err := os.Stat(charterPath); os.IsNotExist(err) {
+			if err := os.WriteFile(charterPath, []byte("Charter content here"), 0o644); err != nil {
+				log.Fatalf("Failed to write %s: %v", charterPath, err)
+			}
+		}
+		// Autofill template fields that should be invariant.
+		tag.CharterLink = charterPath
+		// TagLabel is the part of the label after the "tag/" prefix.
+		tag.TagLabel = strings.ReplaceAll(
+			strings.TrimSpace(
+				strings.TrimPrefix(strings.ToLower(tag.Name), "tag")), " ", "-")
+
 		var tagBuf bytes.Buffer
 		if err := tagTmpl.Execute(&tagBuf, tag); err != nil {
 			log.Fatalf("Tag template execution failed: %v", err)
 		}
 
 		tagFilePath := filepath.Join(tagFolderPath, "README.md")
-		if err := os.WriteFile(tagFilePath, tagBuf.Bytes(), 0644); err != nil {
+		if err := os.WriteFile(tagFilePath, tagBuf.Bytes(), 0o644); err != nil {
 			log.Fatalf("Failed to write %s: %v", tagFilePath, err)
-		}
-		// create charter.md
-		if tag.CharterLink != "" {
-			charterPath := filepath.Join(tagFolderPath, "charter.md")
-			if err := os.WriteFile(charterPath, []byte("Charter content here"), 0644); err != nil {
-				log.Fatalf("Failed to write %s: %v", charterPath, err)
-			}
 		}
 	}
 
@@ -161,21 +172,27 @@ func main() {
 			log.Fatalf("Failed to create folder for TOC subproject %s: %v", tocSubproject.Name, err)
 		}
 
+		charterPath := filepath.Join(tocSubprojectFolderPath, "charter.md")
+		if _, err := os.Stat(charterPath); os.IsNotExist(err) {
+			if err := os.WriteFile(charterPath, []byte("Charter content here"), 0o644); err != nil {
+				log.Fatalf("Failed to write %s: %v", charterPath, err)
+			}
+		}
+		// Autofill template fields that should be invariant.
+		tocSubproject.CharterLink = charterPath
+		// SubprojectLabel is the part of the label after the "sub/" prefix.
+		tocSubproject.SubprojectLabel = strings.ReplaceAll(
+			strings.TrimSpace(
+				strings.TrimSuffix(strings.ToLower(tocSubproject.Name), "subproject")), " ", "-")
+
 		var tocBuf bytes.Buffer
 		if err := tocTmpl.Execute(&tocBuf, tocSubproject); err != nil {
 			log.Fatalf("TOC template execution failed: %v", err)
 		}
 
 		tocReadmePath := filepath.Join(tocSubprojectFolderPath, "README.md")
-		if err := os.WriteFile(tocReadmePath, tocBuf.Bytes(), 0644); err != nil {
+		if err := os.WriteFile(tocReadmePath, tocBuf.Bytes(), 0o644); err != nil {
 			log.Fatalf("Failed to write %s: %v", tocReadmePath, err)
-		}
-		//Create charter.md
-		if tocSubproject.CharterLink != "" {
-			charterPath := filepath.Join(tocSubprojectFolderPath, "charter.md")
-			if err := os.WriteFile(charterPath, []byte("Charter content here"), 0644); err != nil {
-				log.Fatalf("Failed to write %s: %v", charterPath, err)
-			}
 		}
 	}
 
@@ -184,8 +201,8 @@ func main() {
 
 // ensureDir ensures the directory exists.
 func ensureDir(dirPath string) error {
-	if err := os.MkdirAll(dirPath, 0755); err != nil {
-		return fmt.Errorf("failed to create directory %s: %v", dirPath, err)
+	if err := os.MkdirAll(dirPath, 0o755); err != nil {
+		return fmt.Errorf("failed to create directory %s: %w", dirPath, err)
 	}
 	return nil
 }

--- a/generator/tag_readme.tmpl
+++ b/generator/tag_readme.tmpl
@@ -1,5 +1,7 @@
 # {{.Name}}
 
+<!-- THIS FILE IS AUTO-GENERATED FROM /tags.yaml -->
+
 ## Mission Statement
 {{.MissionStatement}}
 

--- a/generator/tag_readme.tmpl
+++ b/generator/tag_readme.tmpl
@@ -46,7 +46,5 @@
 {{- end }}
 {{- end }}
 
-{{- if .TagInitiatives }}
 ## Initiatives
-[{{.Name}} Initiatives]({{.TagInitiatives}})
-{{- end }}
+[{{.Name}} Initiatives](https://github.com/cncf/toc/issues?q=state%3Aopen%20label%3Akind%2Finitiative%20label%3Atag%2F{{.TagLabel}})

--- a/generator/toc_subproject_readme.tmpl
+++ b/generator/toc_subproject_readme.tmpl
@@ -1,5 +1,7 @@
 # {{.Name}}
 
+<!-- THIS FILE IS AUTO-GENERATED FROM /tags.yaml -->
+
 ## Mission Statement
 {{.MissionStatement}}
 

--- a/generator/toc_subproject_readme.tmpl
+++ b/generator/toc_subproject_readme.tmpl
@@ -41,7 +41,5 @@
 {{- end }}
 {{- end }}
 
-{{- if .SubprojectInitiatives }}
 ## Initiatives
-[{{.Name}} Initiatives]({{.SubprojectInitiatives}})
-{{- end }}
+[{{.Name}} Initiatives](https://github.com/cncf/toc/issues?q=is%3Aopen%20label%3Akind%2Finitiative%20label%3Asub%2F{{.SubprojectLabel}})

--- a/tags/tag-developer-experience/README.md
+++ b/tags/tag-developer-experience/README.md
@@ -28,5 +28,6 @@ Databases, Microservices, Streaming, Messaging, API Management, Dev Frameworks.
 
 ## Subprojects
 - **Developer Experience-sub-foo**: [Mailing List](https://lists.cncf.io/g/cncf-tag-developer-experience/)
+
 ## Initiatives
-[TAG Developer Experience Initiatives](https://github.com/cncf/toc/issues?q=label%3Atag%2Fdeveloper-experience-initiative)
+[TAG Developer Experience Initiatives](https://github.com/cncf/toc/issues?q=state%3Aopen%20label%3Akind%2Finitiative%20label%3Atag%2Fdeveloper-experience)

--- a/tags/tag-developer-experience/README.md
+++ b/tags/tag-developer-experience/README.md
@@ -1,5 +1,7 @@
 # TAG Developer Experience
 
+<!-- THIS FILE IS AUTO-GENERATED FROM /tags.yaml -->
+
 ## Mission Statement
 Databases, Microservices, Streaming, Messaging, API Management, Dev Frameworks.
 

--- a/tags/tag-infrastructure/README.md
+++ b/tags/tag-infrastructure/README.md
@@ -29,5 +29,6 @@ Data, Storage, Network, DNS, Compute, Service Mesh, Infrastructure-as-Code, Edge
 
 ## Subprojects
 - **Infrastructure-sub-foo**: [Mailing List](https://lists.cncf.io/g/cncf-tag-infrastructure)
+
 ## Initiatives
-[TAG Infrastructure Initiatives](https://github.com/cncf/toc/labels/tag%2Finfrastructure-initiative)
+[TAG Infrastructure Initiatives](https://github.com/cncf/toc/issues?q=state%3Aopen%20label%3Akind%2Finitiative%20label%3Atag%2Finfrastructure)

--- a/tags/tag-infrastructure/README.md
+++ b/tags/tag-infrastructure/README.md
@@ -1,5 +1,7 @@
 # TAG Infrastructure
 
+<!-- THIS FILE IS AUTO-GENERATED FROM /tags.yaml -->
+
 ## Mission Statement
 Data, Storage, Network, DNS, Compute, Service Mesh, Infrastructure-as-Code, Edge, Sovereignty, Load Balancing
 

--- a/tags/tag-operational-resilience/README.md
+++ b/tags/tag-operational-resilience/README.md
@@ -1,5 +1,7 @@
 # TAG Operational Resilience
 
+<!-- THIS FILE IS AUTO-GENERATED FROM /tags.yaml -->
+
 ## Mission Statement
 Observability, Management, Business Continuity, Resource Optimization, Cost Efficiency, Energy, Performance, Troubleshooting, Reliability, Day 2 Ops
 

--- a/tags/tag-operational-resilience/README.md
+++ b/tags/tag-operational-resilience/README.md
@@ -28,5 +28,6 @@ Observability, Management, Business Continuity, Resource Optimization, Cost Effi
 
 ## Subprojects
 - **Operational Resilience-sub-foo**: [Mailing List](https://lists.cncf.io/g/cncf-tag-operational-resilience)
+
 ## Initiatives
-[TAG Operational Resilience Initiatives](https://github.com/cncf/toc/issues?q=label%3Atag%2Foperational-resilience-initiative)
+[TAG Operational Resilience Initiatives](https://github.com/cncf/toc/issues?q=state%3Aopen%20label%3Akind%2Finitiative%20label%3Atag%2Foperational-resilience)

--- a/tags/tag-security-and-compliance/README.md
+++ b/tags/tag-security-and-compliance/README.md
@@ -1,5 +1,7 @@
 # TAG Security and Compliance
 
+<!-- THIS FILE IS AUTO-GENERATED FROM /tags.yaml -->
+
 ## Mission Statement
 Security hygiene, Policy-as-code, Compliance, Auditing, Threat Modeling, Secure Software Supply Chain
 

--- a/tags/tag-security-and-compliance/README.md
+++ b/tags/tag-security-and-compliance/README.md
@@ -12,9 +12,9 @@ Security hygiene, Policy-as-code, Compliance, Auditing, Threat Modeling, Secure 
 - Evan Anderson (**[@evankanderson](https://github.com/evankanderson)**), Custcodian (Term: 2025-07-01 - 2026-06-30)
 - Marina Moore (**[@mnm678](https://github.com/mnm678)**), Edera (Term: 2025-07-01 - 2027-06-30)
 ### Tech Leads
-- Brandt Keller (**[@brandtkeller](https://github.com/brandtkeller)**), Defense Unicorns (Term: 2025-07-02 - 2026-06-30)
+- Brand Keller (**[@brandkeller](https://github.com/brandkeller)**) (Term: 2025-07-02 - 2026-06-30)
 - Jennifer Power (**[@jpower432](https://github.com/jpower432)**), Red Hat (Term: 2025-07-02 - 2026-06-30)
-- John Kjell (**[@jkjell](https://github.com/jkjell)**), ControlPlane (Term: 2025-07-02 - 2027-06-30)
+- John Kjell (**[@jkjell](https://github.com/jkjell)**) (Term: 2025-07-02 - 2027-06-30)
 - Justin Cappos (**[@JustinCappos](https://github.com/JustinCappos)**), New York University (Term: 2025-07-02 - 2027-06-30)
 - Michael Lieberman (**[@mlieberman85](https://github.com/mlieberman85)**) (Term: 2025-07-02 - 2026-06-30)
 - Yoshiyuki Tabata (**[@y-tabata](https://github.com/y-tabata)**), Hitachi (Term: 2025-07-02 - 2026-06-30)
@@ -30,5 +30,6 @@ Security hygiene, Policy-as-code, Compliance, Auditing, Threat Modeling, Secure 
 
 ## Subprojects
 - **Security and Compliance-sub-foo**: [Mailing List](https://lists.cncf.io/g/cncf-tag-security-and-compliance)
+
 ## Initiatives
-[TAG Security and Compliance Initiatives](https://github.com/cncf/toc/issues?q=label%3Atag%2Fsecurity-and-compliance-initiative)
+[TAG Security and Compliance Initiatives](https://github.com/cncf/toc/issues?q=state%3Aopen%20label%3Akind%2Finitiative%20label%3Atag%2Fsecurity-and-compliance)

--- a/tags/tag-workloads-foundation/README.md
+++ b/tags/tag-workloads-foundation/README.md
@@ -29,5 +29,6 @@ Containers, OS, Runtime, Virtual Machines, Serverless, Web Assembly, Batch, Sche
 
 ## Subprojects
 - **Workloads Foundation-sub-foo**: [Mailing List](https://lists.cncf.io/g/cncf-tag-workloads-foundation)
+
 ## Initiatives
-[TAG Workloads Foundation Initiatives](https://github.com/cncf/toc/issues?q=label%3Atag%2Fworkloads-foundation-initiative)
+[TAG Workloads Foundation Initiatives](https://github.com/cncf/toc/issues?q=state%3Aopen%20label%3Akind%2Finitiative%20label%3Atag%2Fworkloads-foundation)

--- a/tags/tag-workloads-foundation/README.md
+++ b/tags/tag-workloads-foundation/README.md
@@ -1,5 +1,7 @@
 # TAG Workloads Foundation
 
+<!-- THIS FILE IS AUTO-GENERATED FROM /tags.yaml -->
+
 ## Mission Statement
 Containers, OS, Runtime, Virtual Machines, Serverless, Web Assembly, Batch, Scheduler, Orchestrator, Deployment, Dynamic Scaling, CI/CD
 

--- a/toc_subprojects/contributor-strategy-and-advocacy-subproject/README.md
+++ b/toc_subprojects/contributor-strategy-and-advocacy-subproject/README.md
@@ -15,5 +15,6 @@ Foo-Baz-Bar
 ## Contact
 - Slack: [Tag Contributor Strategy and Advocacy SubProject Slack](https://cloud-native.slack.com/archives/C08N4CKUHB2)
 - [Mailing List](https://lists.cncf.io/g/contributor-strategy-subproject)
+
 ## Initiatives
-[Contributor Strategy and Advocacy SubProject Initiatives](https://github.com/cncf/toc/issues?q=label%3Atoc%2Fcontributor-strategy-subproject-initiative)
+[Contributor Strategy and Advocacy SubProject Initiatives](https://github.com/cncf/toc/issues?q=is%3Aopen%20label%3Akind%2Finitiative%20label%3Asub%2Fcontributor-strategy-and-advocacy)

--- a/toc_subprojects/contributor-strategy-and-advocacy-subproject/README.md
+++ b/toc_subprojects/contributor-strategy-and-advocacy-subproject/README.md
@@ -1,5 +1,7 @@
 # Contributor Strategy and Advocacy SubProject
 
+<!-- THIS FILE IS AUTO-GENERATED FROM /tags.yaml -->
+
 ## Mission Statement
 Foo-Baz-Bar
 

--- a/toc_subprojects/mentoring-subproject/README.md
+++ b/toc_subprojects/mentoring-subproject/README.md
@@ -15,5 +15,6 @@ Foo-Baz-Bar
 ## Contact
 - Slack: [Tag Mentoring SubProject Slack](https://cloud-native.slack.com/archives/CGPK98JNQ)
 - [Mailing List](https://lists.cncf.io/g/tag-cs-mentoring-wg)
+
 ## Initiatives
-[Mentoring SubProject Initiatives](https://github.com/cncf/toc/issues?q=label%3Atoc%2Fmentoring-subproject-initiative)
+[Mentoring SubProject Initiatives](https://github.com/cncf/toc/issues?q=is%3Aopen%20label%3Akind%2Finitiative%20label%3Asub%2Fmentoring)

--- a/toc_subprojects/mentoring-subproject/README.md
+++ b/toc_subprojects/mentoring-subproject/README.md
@@ -1,5 +1,7 @@
 # Mentoring SubProject
 
+<!-- THIS FILE IS AUTO-GENERATED FROM /tags.yaml -->
+
 ## Mission Statement
 Foo-Baz-Bar
 

--- a/toc_subprojects/project-reviews-subproject/README.md
+++ b/toc_subprojects/project-reviews-subproject/README.md
@@ -1,5 +1,7 @@
 # Project Reviews SubProject
 
+<!-- THIS FILE IS AUTO-GENERATED FROM /tags.yaml -->
+
 ## Mission Statement
 Foo-Baz-bar
 

--- a/toc_subprojects/project-reviews-subproject/README.md
+++ b/toc_subprojects/project-reviews-subproject/README.md
@@ -16,5 +16,6 @@ Foo-Baz-bar
 - Slack: [Tag Project Reviews SubProject Slack](https://cloud-native.slack.com/archives/C08M8L74NAJ)
 - [Mailing List](https://lists.cncf.io/g/cncf-project-reviews-subproject)
 - TOC Liaison: Karena Angell (**[@angellk](https://github.com/angellk)**)
+
 ## Initiatives
-[Project Reviews SubProject Initiatives](https://github.com/cncf/toc/issues?q=label%3Atoc%2Fcontributor-strategy-subproject-initiative)
+[Project Reviews SubProject Initiatives](https://github.com/cncf/toc/issues?q=is%3Aopen%20label%3Akind%2Finitiative%20label%3Asub%2Fproject-reviews)


### PR DESCRIPTION
Fixes three issues (because I got in there and got on a roll):

* The generator script was overwriting `charter.md` even if it had useful contents (examples: #1813, #1817)

* The `tags.yaml` links for TAG and Subproject initiatives were not working in all cases.  Given the uniformity in the repo, there's no point in making humans maintain this, so I auto-generated the links.

* The PR automation was not using the `-s` (signoff) flag on commits, so the generated commits were failing DCO (examples: #1813, #1817).  I'm still not 100% comfortable with this approach, as we're _copying_ the contents of the PR without providing original author attribution, but I'm picking this as a stopping point for now.

