### PR TITLE
Fix inconsistency in project DD templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/template-graduation-application.md
+++ b/.github/ISSUE_TEMPLATE/template-graduation-application.md
@@ -50,10 +50,6 @@ N/A
 
 <!-- (Project assertion goes here) --> 
 
-- [ ]  **TAG provides insight/recommendation of the project in the context of the landscape**
-
-<!-- (Project assertion goes here) --> 
-
 - [ ]  **All project metadata and resources are [vendor-neutral](https://contribute.cncf.io/maintainers/community/vendor-neutrality/).**
 
 <!-- (Project assertion goes here) --> 

--- a/.github/ISSUE_TEMPLATE/template-graduation-application.md
+++ b/.github/ISSUE_TEMPLATE/template-graduation-application.md
@@ -58,7 +58,7 @@ N/A
 
 <!-- (Project assertion goes here) --> 
 
-- [ ] **Review and acknowledgement of expectations for graduated projects and requirements for moving forward through the CNCF Maturity levels.**		
+- [ ] **Review and acknowledgement of expectations for [Sandbox](sandbox.cncf.io) projects and requirements for moving forward through the CNCF Maturity levels.**		
    - [ ] Met during Project's application on DD-MMM-YYYY.
 
 <!-- (Project assertion goes here) --> 

--- a/.github/ISSUE_TEMPLATE/template-incubation-application.md
+++ b/.github/ISSUE_TEMPLATE/template-incubation-application.md
@@ -50,10 +50,6 @@ N/A
 
 <!-- (Project assertion goes here) --> 
 
-- [ ] **TAG provides insight/recommendation of the project in the context of the landscape**
-
-<!-- (Project assertion goes here) --> 
-
 - [ ] **All project metadata and resources are [vendor-neutral](https://contribute.cncf.io/maintainers/community/vendor-neutrality/).**
 
 <!-- (Project assertion goes here) --> 

--- a/operations/toc-templates/template-dd-pr-graduation.md
+++ b/operations/toc-templates/template-dd-pr-graduation.md
@@ -37,10 +37,12 @@ N/A
 
 <!-- (TOC Evaluation goes here) --> 
 
-- [ ] **Review and acknowledgement of expectations for [graduated](sandbox.cncf.io) projects and requirements for moving forward through the CNCF Maturity levels.**		
+- [ ] **Review and acknowledgement of expectations for [Sandbox](sandbox.cncf.io) projects and requirements for moving forward through the CNCF Maturity levels.**		
    - [ ] Met during Project's application on DD-MMM-YYYY.
 
 <!-- (TOC Evaluation goes here) --> 
+
+- [ ] **Due Diligence Review.**
 
 Completion of this due diligence document, resolution of concerns raised, and presented for public comment satisfies the Due Diligence Review criteria.
 


### PR DESCRIPTION
This PR fixes a few inconsistencies in the graduation and incubation templates located in `.github/` and `operations/toc-templates/`:

1. Added missing "Due Diligence Review" check list item in graduation template
2. Corrected inconsistency in "Review and acknowledgement of expectations for Sandbox projects
and requirements for moving forward through the CNCF Maturity levels". It's because the sandbox
requirements set expectations for how to be a CNCF project.
3. Removed requirement for tag recommendation in templates under `.github/`, to sync changes made by https://github.com/cncf/toc/pull/1814


Signed-off-by: Kevin Wang <kevinwzf0126@gmail.com>