### PR TITLE
Add tag environmental sustainability emeritus chairs

### DIFF
--- a/tags/emeritus_leaders.md
+++ b/tags/emeritus_leaders.md
@@ -1,28 +1,31 @@
-| TAG                      | Emeritus Chair                                           |
-|--------------------------|----------------------------------------------------------|
-| TAG App Delivery         | [Jennifer Strejevitch](https://github.com/Jenniferstrej) |
-| TAG App Delivery         | [Hongchao Deng](https://github.com/hongchaodeng)         |
-| TAG App Delivery         | [Bryan Liles](https://github.com/bryanl)                 |
-| TAG App Delivery         | [Lei Zhang](https://github.com/resouer)                  |
-| TAG App Delivery         | [Alex Jones](https://github.com/alexsjones)              |
-| TAG App Delivery         | [Josh Gavant](https://github.com/joshgav)                |
-| TAG App Delivery         | [Karena Angell](https://github.com/angellk)              |
-| TAG App Delivery         | [Thomas Schuetz](https://github.com/thschue)             |
-| TAG App Delivery         | [Lian Li](https://github.com/lianmakesthings)            |
-| TAG App Delivery         | [Roberth Strand](https://github.com/roberthstrand)       |
-| TAG Contributor Strategy | [Gerred Dillon](https://github.com/gerred)               |
-| TAG Contributor Strategy | [Paris Pittman](https://github.com/parispittman)         |
-| TAG Contributor Strategy | [Stephen Augustus](https://github.com/justaugustus)      |
-| TAG Observability        | [Alolita Sharma](https:github.com/alolita)               |
-| TAG Observability        | [Matt Young](https:github.com/halcyondude)               |
-| TAG Observability        | [Richard Hartmann](https://github.com/RichiH)            |
-| TAG Security             | [Sarah Allen](https://github.com/ultrasaurus)            |
-| TAG Security             | [Jeyappragash Jeyakeerthi](https://github.com/pragashj)  |
-| TAG Security             | [Dan Shaw](https://github.com/dshaw)                     |
-| TAG Security             | [Emily Fox](https://github.com/TheFoxAtWork)             |
-| TAG Security             | [Brandon Lum](https://github.com/lumjjb)                 |
-| TAG Security             | [Aradhna Chetal](https://github.com/achetal01)           |
-| TAG Security             | [Andrew Martin](https://github.com/sublimino)            |
-| TAG Storage              | [Erin Boyd](https://github.com/erinboyd)                 | 
-| TAG Network              | [Lin Sun](https://github.com/linsun)                     |
-
+| TAG                              | Emeritus Chair                                           |
+| -------------------------------- | -------------------------------------------------------- |
+| TAG App Delivery                 | [Jennifer Strejevitch](https://github.com/Jenniferstrej) |
+| TAG App Delivery                 | [Hongchao Deng](https://github.com/hongchaodeng)         |
+| TAG App Delivery                 | [Bryan Liles](https://github.com/bryanl)                 |
+| TAG App Delivery                 | [Lei Zhang](https://github.com/resouer)                  |
+| TAG App Delivery                 | [Alex Jones](https://github.com/alexsjones)              |
+| TAG App Delivery                 | [Josh Gavant](https://github.com/joshgav)                |
+| TAG App Delivery                 | [Karena Angell](https://github.com/angellk)              |
+| TAG App Delivery                 | [Thomas Schuetz](https://github.com/thschue)             |
+| TAG App Delivery                 | [Lian Li](https://github.com/lianmakesthings)            |
+| TAG App Delivery                 | [Roberth Strand](https://github.com/roberthstrand)       |
+| TAG Contributor Strategy         | [Gerred Dillon](https://github.com/gerred)               |
+| TAG Contributor Strategy         | [Paris Pittman](https://github.com/parispittman)         |
+| TAG Contributor Strategy         | [Stephen Augustus](https://github.com/justaugustus)      |
+| TAG Environmental Sustainability | [Max Körbächer](https://github.com/mkorbi)               |
+| TAG Environmental Sustainability | [Marlow Warnicke](https://github.com/catblade)           |
+| TAG Environmental Sustainability | [Leonard Pahlke](https://github.com/leonardpahlke)       |
+| TAG Environmental Sustainability | [Kristina Devochko](https://github.com/guidemetothemoon) |
+| TAG Network                      | [Lin Sun](https://github.com/linsun)                     |
+| TAG Observability                | [Alolita Sharma](https:github.com/alolita)               |
+| TAG Observability                | [Matt Young](https:github.com/halcyondude)               |
+| TAG Observability                | [Richard Hartmann](https://github.com/RichiH)            |
+| TAG Security                     | [Sarah Allen](https://github.com/ultrasaurus)            |
+| TAG Security                     | [Jeyappragash Jeyakeerthi](https://github.com/pragashj)  |
+| TAG Security                     | [Dan Shaw](https://github.com/dshaw)                     |
+| TAG Security                     | [Emily Fox](https://github.com/TheFoxAtWork)             |
+| TAG Security                     | [Brandon Lum](https://github.com/lumjjb)                 |
+| TAG Security                     | [Aradhna Chetal](https://github.com/achetal01)           |
+| TAG Security                     | [Andrew Martin](https://github.com/sublimino)            |
+| TAG Storage                      | [Erin Boyd](https://github.com/erinboyd)                 |


### PR DESCRIPTION
Adding @mkorbi, @catblade, @leonardpahlke and @guidemetothemoon to the list of emeritus TAG chairs.

https://github.com/cncf/tag-env-sustainability?tab=readme-ov-file#tag-environmental-sustainability-co-chairs
