### PR TITLE
Adds GTR questions for license and attribution for third party components

### DIFF
--- a/toc_subprojects/project-reviews-subproject/general-technical-questions.md
+++ b/toc_subprojects/project-reviews-subproject/general-technical-questions.md
@@ -170,8 +170,7 @@ If this is the case for your project, please mark it as not-applicable (N/A) and
 ### Dependencies
 
   * Describe the specific running services the project depends on in the cluster.  
-  * Describe the project’s dependency lifecycle policy.
-  * How does the project handle licensing and copyright attribution for its third-party dependencies, including those in its container images? Please detail the process for aligning with CNCF [recommendations](https://github.com/cncf/foundation/blob/main/policies-guidance/recommendations-for-attribution.md) for attribution notices.
+  * Describe the project’s dependency lifecycle policy.  
   * How does the project incorporate and consider source composition analysis as part of its development and security hygiene? Describe how this source composition analysis (SCA) is tracked.
   * Describe how the project implements changes based on source composition analysis (SCA) and the timescale.
 
@@ -179,6 +178,15 @@ If this is the case for your project, please mark it as not-applicable (N/A) and
 
   * How does this project recover if a key component or feature becomes unavailable? e.g Kubernetes API server, etcd, database, leader node, etc.  
   * Describe the known failure modes.
+
+### Compliance
+
+  * What steps does the project take to ensure that all third-party code and components have correct and complete attribution and license notices?
+  * Describe how the project ensures alignment with CNCF [recommendations](https://github.com/cncf/foundation/blob/main/policies-guidance/recommendations-for-attribution.md) for attribution notices.
+    <!--Note that each question describes a use case covered by the referenced policy document.-->
+    * How are notices managed for third-party code incorporated directly into the project's source files?
+    * How are notices retained for unmodified third-party components included within the project's repository?
+    * How are notices for all dependencies obtained at build time included in the project's distributed build artifacts (e.g. compiled binaries, container images)?
 
 ### Security
 


### PR DESCRIPTION
The PR proposes an new Day 2 section of the General Technical Review questions to include a question pertaining to license compliance and copyright attribution for third party components.

This addition is an outcome of a dicussion at the TAG SC public meeting (AMER) that occurred on 09/24.
This aims to extend the questions to cover governance/compliance risks and conformance to CNCF guidance around open source license compliance.