### PR TITLE
Enable GitVote audit page

### DIFF
--- a/.gitvote.yml
+++ b/.gitvote.yml
@@ -1,3 +1,5 @@
+audit:
+  enabled: true
 profiles:
   default:
     duration: 26w
@@ -19,4 +21,3 @@ profiles:
         - cncf-toc-voters
       exclude_team_maintainers: true
     close_on_passing: true
-


### PR DESCRIPTION
Please see the [GitVote reference config file](https://github.com/cncf/gitvote/blob/e504b545d52380af52e8752386cebf5c443aafe7/docs/config/.gitvote.yml#L9-L30) for more details.

We'll deploy this feature later on today, but it'd be great if you could merge this PR first so that we can run some tests 🙂

/cc @jeefy