### PR TITLE
Update TAG Operational Resilience charter to remove conformance program language

### DIFF
--- a/tags/tag-operational-resilience/charter.md
+++ b/tags/tag-operational-resilience/charter.md
@@ -40,7 +40,6 @@ This TAG covers the following sub-domains and topics within its scope:
   * **Reliability:** The ability of a system to perform its required functions under stated conditions for a specified period of time.
   * **Day 2 Ops:** A focus on the post-deployment activities required to keep a system running smoothly, including maintenance, scaling, updating and upgrading.
   * **Chaos Engineering:** The practice of experimenting on a system to build confidence in its capability to withstand turbulent and unexpected conditions.
-* **Conformance Programs:** Lead the design and ownership of conformance initiatives that enable end users to adopt and select platforms and tools aligned with established standards for operational resilience.
 
 ### Out of Scope
 


### PR DESCRIPTION
Remove the conformance language from the TAG charter as not applicable to this TAG.

Any conformance program that spans multiple projects within the CNCF would first come through the TOC to then be discussed and then put forward to the CNCF Governing Board for a vote.

At that time, once approved, the TOC would then determine the appropriate Subproject, Working Group or other avenue for the conformance program.

Having the language here within a TAG violates the process and scoping.