### PR TITLE
Update Gitvote wait time to close

### DIFF
--- a/.gitvote.yml
+++ b/.gitvote.yml
@@ -10,7 +10,7 @@ profiles:
         - cncf-toc-voters
       exclude_team_maintainers: true
     close_on_passing: true
-    close_on_passing_min_wait: "2 day"
+    close_on_passing_min_wait: "2 days"
     announcements:
       discussions:
         category: announcements


### PR DESCRIPTION
As discussed on toc offsite, this PR makes gitvote wait for 2 more days before closing after the vote pass with minimal binding votes.
This change makes the voting process more friendly for members located in multiple timezones.