### PR TITLE
make copacetic GTR render in GitHub

### DIFF
--- a/projects/copacetic/copa-general-technical-review.md
+++ b/projects/copacetic/copa-general-technical-review.md
@@ -1,4 +1,4 @@
-# # General Technical Review - Project Copacetic / Sandbox
+# General Technical Review - Project Copacetic / Sandbox
 
 - **Project:** Copacetic
 - **Project Version:** v0.12.0-rc.2


### PR DESCRIPTION
The GTR doc for `copacetic` does not have the `.md` extension, causing it not to render in GitHub's interface. It will be easier for reviewers to read the review if it renders in GitHub. This PR adds that extension to do so. It also removes an extraneous `#` from the first line :wink: 