### PR TITLE
Fix TAG Initiatives link in multiple tags readme

### DIFF
--- a/tags/tag-developer-experience/README.md
+++ b/tags/tag-developer-experience/README.md
@@ -29,5 +29,6 @@ Databases, Microservices, Streaming, Messaging, API Management, Dev Frameworks.
 - TOC Liaison: Katie Gamanji (**[@kgamanji](https://github.com/kgamanji)**)
 
 ## Subprojects
+
 ## Initiatives
-[TAG Developer Experience Initiatives](https://github.com/cncf/toc/issues?q=label%3Atag%2Fdeveloper-experience-initiative)
+[TAG Developer Experience Initiatives](https://github.com/cncf/toc/issues?q=state%3Aopen%20label%3Atag%2Fdeveloper-experience%20label%3Akind%2Finitiative)

--- a/tags/tag-infrastructure/README.md
+++ b/tags/tag-infrastructure/README.md
@@ -30,5 +30,6 @@ Data, Storage, Network, DNS, Compute, Service Mesh, Infrastructure-as-Code, Edge
 - TOC Liaison: Karena Angell (**[@angellk](https://github.com/angellk)**)
 
 ## Subprojects
+
 ## Initiatives
-[TAG Infrastructure Initiatives](https://github.com/cncf/toc/labels/tag%2Finfrastructure-initiative)
+[TAG Infrastructure Initiatives](https://github.com/cncf/toc/issues?q=state%3Aopen%20label%3Atag%2Finfrastructure%20label%3Akind%2Finitiative)

--- a/tags/tag-operational-resilience/README.md
+++ b/tags/tag-operational-resilience/README.md
@@ -34,5 +34,6 @@ The purpose of the Green Reviews Subproject is to help CNCF projects to review t
 To support CNCF projects, project maintainers and contributors, there is a need for a systematic approach to assess every project's sustainability footprint and energy consumption. Implementing a structured review process for this purpose would greatly benefit the CNCF ecosystem, establishing it as a best practice. Such a process would enable stakeholders to evaluate and enhance the sustainability of CNCF projects, promoting their long-term viability and environmental responsibility.
 
 - [Mailing List](https://lists.cncf.io/g/cncf-tag-operational-resilience)
+
 ## Initiatives
-[TAG Operational Resilience Initiatives](https://github.com/cncf/toc/issues?q=label%3Atag%2Foperational-resilience-initiative)
+[TAG Operational Resilience Initiatives](https://github.com/cncf/toc/issues?q=state%3Aopen%20label%3Atag%2Foperational-resilience%20label%3Akind%2Finitiative)

--- a/tags/tag-workloads-foundation/README.md
+++ b/tags/tag-workloads-foundation/README.md
@@ -21,7 +21,7 @@ To define and advance practices and standards for fundamental cloud native workl
 - Stephen Rust (**[@srust](https://github.com/srust)**) (Term: 2025-07-02 - 2026-06-30)
 
 ## Meetings
-- **TAG Workloads Foundation Meetings**: [Calendar](https://zoom-lfx.platform.linuxfoundation.org/meetings/tag-workloads-foundation?view=list) | [Recordings](https://www.youtube.com/@CNCFTAGWorkloadsFoundation)
+- **TAG Workloads Foundation Meetings**: [Calendar](https://zoom-lfx.platform.linuxfoundation.org/meetings/tag-workloads-foundation?view=list) | [Recordings](https://www.youtube.com/@CNCFTAGWorkloadsFoundation) | [Meeting Notes and Agenda](https://notes.cncf.io/s/1aNdplhtl)
 
 ## Contact
 - Slack: [Tag TAG Workloads Foundation Slack](https://cloud-native.slack.com/archives/C08K71W9HAS)
@@ -62,5 +62,6 @@ Deliverable(s) or exit criteria:
 * User stories published doc for Batch systems (already in process)
 
 - [Mailing List](https://lists.cncf.io/g/cncf-tag-workloads-foundation)
+
 ## Initiatives
-[TAG Workloads Foundation Initiatives](https://github.com/cncf/toc/issues?q=label%3Atag%2Fworkloads-foundation-initiative)
+[TAG Workloads Foundation Initiatives](https://github.com/cncf/toc/issues?q=state%3Aopen%20label%3Atag%2Fworkloads-foundation%20label%3Akind%2Finitiative)


### PR DESCRIPTION
1. The Initiatives link for TAG DexEx, TAG Infra, TAG OR, TAG WF were broken, this PR fixes them.
2. Also added meeting notes link to TAG Workloads Foundation README.