### PR TITLE
Fix: Add Fluid community meeting calendar link

### DIFF
--- a/projects/fluid/fluid-incubation-proposal.md
+++ b/projects/fluid/fluid-incubation-proposal.md
@@ -245,7 +245,11 @@ Community members are able to join community meetings on a bi-weekly basis. The 
 
 Community meetings are held in Mandarin, and are a great way to engage with the maintainers and get involved in project development. 
 
-TODO: calendar for meetings
+**Meeting Schedule:**
+- **Time:** 16:00 Thursday, bi-weekly (Beijing/Shanghai timezone)
+- **Platform:** DingTalk (Meeting Id: 351 670 2037)
+- **Language:** Simplified Chinese
+- **Full schedule and meeting minutes:** [Fluid Community Meeting Schedule](https://github.com/fluid-cloudnative/community/wiki/Meeting-Schedule)
 
 
 - [x] **Documentation of how to contribute, with increasing detail as the project matures.**


### PR DESCRIPTION
## What this PR does
Replaces TODO comment with comprehensive Fluid community meeting information.

## Changes Made
- **File:** `projects/fluid/fluid-incubation-proposal.md` (line 248-252)
- **Before:** `TODO: calendar for meetings`
- **After:** Complete meeting schedule with platform details and official link

## Details Added
- Meeting time: 16:00 Thursday, bi-weekly (Beijing/Shanghai timezone)
- Platform: DingTalk (Meeting Id: 351 670 2037)
- Language: Simplified Chinese
- Link to full schedule: https://github.com/fluid-cloudnative/community/wiki/Meeting-Schedule

## Testing
- [x] Verified link works and points to correct meeting schedule
- [x] Confirmed meeting details are accurate from official source
- [x] Checked markdown formatting is correct

Fixes #2009 
