### PR TITLE
Clarify GTR security questions to focus on Cloud Native Security Tenets

### DIFF
--- a/.archive/resources/toc-supporting-guides/general-technical-questions.md
+++ b/.archive/resources/toc-supporting-guides/general-technical-questions.md
@@ -107,9 +107,8 @@ If this is the case for your project, please mark it as not-applicable (N/A) and
 ### Security
 
   * Please provide a link to the project’s cloud native [security self assessment](https://tag-security.cncf.io/community/assessments/).  
-  * Please review the [Cloud Native Security Tenets](https://github.com/cncf/tag-security/blob/main/security-whitepaper/secure-defaults-cloud-native-8.md) from TAG Security.  
-    * How are you satisfying the tenets of cloud native security projects?  
-    * Describe how each of the cloud native principles apply to your project.  
+  * Please review the [Cloud Native Security Tenets](https://github.com/cncf/contribute-site/blob/main/docs/community/tags/security-and-compliance/publications/secure-defaults-cloud-native-8.md) from TAG Security.  
+    * How are you satisfying the tenets of cloud native security projects?
     * How do you recommend users alter security defaults in order to "loosen" the security of the project? Please link to any documentation the project has written concerning these use cases.  
   * Security Hygiene  
     * Please describe the frameworks, practices and procedures the project uses to maintain the basic health and security of the project.   

--- a/toc_subprojects/project-reviews-subproject/general-technical-questions.md
+++ b/toc_subprojects/project-reviews-subproject/general-technical-questions.md
@@ -107,9 +107,8 @@ If this is the case for your project, please mark it as not-applicable (N/A) and
 ### Security
 
   * Please provide a link to the project’s cloud native [security self assessment](https://tag-security.cncf.io/community/assessments/).  
-  * Please review the [Cloud Native Security Tenets](https://github.com/cncf/tag-security/blob/main/community/resources/security-whitepaper/secure-defaults-cloud-native-8.md) from TAG Security.  
-    * How are you satisfying the tenets of cloud native security projects?  
-    * Describe how each of the cloud native principles apply to your project.  
+  * Please review the [Cloud Native Security Tenets](https://github.com/cncf/contribute-site/blob/main/docs/community/tags/security-and-compliance/publications/secure-defaults-cloud-native-8.md) from TAG Security.  
+    * How are you satisfying the tenets of cloud native security projects?
     * How do you recommend users alter security defaults in order to "loosen" the security of the project? Please link to any documentation the project has written concerning these use cases.  
   * Security Hygiene  
     * Please describe the frameworks, practices and procedures the project uses to maintain the basic health and security of the project.   


### PR DESCRIPTION
This PR removes the redundant `cloud native principles` question from the Security section of `General Technical Review questions`. Based on PR #1441 discussions [here](https://github.com/cncf/toc/pull/1441/changes#r1777528431), the question referencing `cloud native principles` was intended to specifically address the `Cloud Native Security Tenets` (the linked Cloud Native 8 document), not generic principles. 

Fixes #1673 
