### PR TITLE
Add new labels and update existing ones in labels.yaml and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/gov-review.yml
+++ b/.github/ISSUE_TEMPLATE/gov-review.yml
@@ -5,7 +5,7 @@ labels:
   - needs-triage
   - kind/review
   - review/governance 
-  - sub/project-review
+  - sub/project-reviews
 body:
   - type: input
     id: name

--- a/.github/ISSUE_TEMPLATE/template-graduation-application.md
+++ b/.github/ISSUE_TEMPLATE/template-graduation-application.md
@@ -3,7 +3,7 @@ name: Project Graduation Application
 about: This template provides the project with a framework to inform the TOC of their conformance to the Graduation Level Criteria.
 title: "[Graduation] $PROJECT Graduation Application"
 labels:
-- dd/triage/needs-triage
+- dd/needs-triage
 - level/graduation
 - kind/dd
 - toc

--- a/.github/ISSUE_TEMPLATE/template-incubation-application.md
+++ b/.github/ISSUE_TEMPLATE/template-incubation-application.md
@@ -3,7 +3,7 @@ name: Project Incubation Application
 about: This template provides the project with a framework to inform the TOC of their conformance to the Incubation Level Criteria.
 title: "[Incubation] $PROJECT Incubation Application"
 labels:
-- dd/triage/needs-triage
+- dd/needs-triage
 - level/incubation
 - kind/dd
 - toc

--- a/.github/labels.yaml
+++ b/.github/labels.yaml
@@ -83,6 +83,9 @@ labels:
 - name: gitvote/closed
   description: ''
   color: ededed
+- name: gitvote/open
+  description: ''
+  color: ededed
 - name: gitvote/passed
   description: ''
   color: ededed
@@ -106,6 +109,9 @@ labels:
   color: 61D6C3
 - name: kind/docs
   description: Docs related changes or updates
+  color: 61D6C3
+- name: kind/election
+  description: Election related item
   color: 61D6C3
 - name: kind/enhancement
   description: General items related to enhancements or improvements.
@@ -293,18 +299,6 @@ ruleset:
     spec: 
       match: tag/{{ argv.0 }}
 
-- name: test
-  kind: filePath
-  spec:
-    matchPath: "utilities/labeler/*"
-  actions:
-  - kind: remove-label
-    spec:
-      match: needs-group
-  - kind: apply-label
-    spec:
-      label: toc
-
 # has to come before /toc otherwise it will try and match as "toc/{{argv.0}}"
 - name: remove-toc-init
   kind: match
@@ -386,6 +380,7 @@ ruleset:
       - needs-kind
       - kind/dd
       - kind/docs
+      - kind/election
       - kind/enhancement
       - kind/initiative
       - kind/meeting
@@ -493,14 +488,14 @@ ruleset:
     command: /dd/triage
     rules:
     - matchList:
-      - dd/triage/needs-triage
+      - dd/needs-triage
       - dd/triage/needs-adopters
       - dd/triage/needs-more-information
       - dd/triage/needs-security-assessment
   actions:
   - kind: remove-label
     spec:
-      match: dd/triage/needs-triage
+      match: dd/needs-triage
   - kind: apply-label
     spec:
       label: dd/triage/{{ argv.0 }}

--- a/.github/workflows/create-tech-review.yml
+++ b/.github/workflows/create-tech-review.yml
@@ -38,7 +38,7 @@ jobs:
             };
 
             const LABELS_TECH_REVIEW = [
-              'needs-triage', 'kind/initiative', 'review/tech', 'sub/project-review'
+              'needs-triage', 'kind/initiative', 'review/tech', 'sub/project-reviews'
             ];
 
             const COMMENT_MARKERS = {


### PR DESCRIPTION
- Introduced 'gitvote/open' and 'kind/election' labels in labels.yaml.
- Updated 'sub/project-review' to 'sub/project-reviews' in issue templates.
- Changed label references from 'dd/triage/needs-triage' to 'dd/needs-triage' in multiple issue templates and workflows.

These changes enhance the labeling system for better issue tracking and categorization.