### PR TITLE
Security: Fix 4 findings in GitHub Actions workflows

### DIFF
--- a/.github/workflows/tags_yaml_branch_pr_processing.yaml
+++ b/.github/workflows/tags_yaml_branch_pr_processing.yaml
@@ -44,11 +44,12 @@ jobs:
       - name: Commit and push changes if any
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
           git add .
           if [ -n "$(git status --porcelain)" ]; then
             git commit -sm "Update README based on tags.yaml changes"
-            git push origin HEAD:${{ github.event.pull_request.head.ref }}
+            git push origin HEAD:$PR_HEAD_REF
           else
             echo "No changes to commit"
           fi


### PR DESCRIPTION
## Security: 4 findings across 2 rules

### Fixed (deterministic, no AI)

**shell-injection-expr** — [What is this?](https://sentinel-bot.copilotkit.dev/rules/shell-injection-expr)
- `tags_yaml_branch_pr_processing.yaml` line 51: Attacker-controllable expression ${{ github.event.pull_request.head.ref }} in run: block — shell injection risk

### Requires manual review

**dangerous-triggers** — [What is this?](https://sentinel-bot.copilotkit.dev/rules/dangerous-triggers)
- `labeler.yaml` line 22: pull_request_target + checkout of PR head — fork code runs with base repo secrets
  - Fix: Use pull_request trigger instead, or don't checkout PR head code
- `tags_yaml_branch_pr_processing.yaml` line 24: pull_request_target + checkout of PR head — fork code runs with base repo secrets
  - Fix: Use pull_request trigger instead, or don't checkout PR head code
- `tags_yaml_fork_pr_processing.yaml` line 27: pull_request_target + checkout of PR head — fork code runs with base repo secrets
  - Fix: Use pull_request trigger instead, or don't checkout PR head code

### How this was detected

This finding was identified by deterministic pattern matching — no AI or machine learning was used in the detection. Sentinel uses static analysis rules that match known-vulnerable YAML patterns against a database of documented exploit vectors. Every finding maps to a specific, reproducible pattern. [Source code](https://github.com/jpr5/sentinel) is open for inspection.

---
<sub>&#x1f6e1;&#xfe0f; This PR was generated by [Sentinel](https://sentinel.copilotkit.dev), an open-source security scanner. [Why this PR?](https://medium.com/@jordanritter/security-hardening-github-workflows-at-scale-d291a33774e1) · Free, no tracking</sub>

[&#x2705; Add Sentinel to this repo](https://sentinel-bot.copilotkit.dev/adopt?repo=cncf%2Ftoc&token=6e8338f2-41ad-4e7e-90ec-90d7285bf492) · [&#x1f6ab; Opt out of future PRs](https://sentinel-bot.copilotkit.dev/opt-out?repo=cncf%2Ftoc&token=dee851aa-50e6-4c75-9352-4a63fea12889)
