### PR TITLE
Rename TOC Shadows to TOC Alternates

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,10 @@ The technical direction of the ecosystem is problem-centric. We encourage and su
 * **Mario Fahlandt** (term: 2 years - start date: 5/12/2026 - 5/12/2028) [GB-appointed]
 * **Mauricio Salatino** (term: 2 years - start date: 5/12/2026 - 5/12/2028) [Maintainer-appointed]
 
-## TOC Shadows
+## TOC Alternates
 
-* **Katie Gamanji** (term: 1 year - start date: 5/12/2026 - 5/12/2027) [GB-appointed][shadow]
-* **Ricardo Aravena** (term: 1 year - start date: 5/12/2026 - 5/12/2027) [GB-appointed][shadow]
+* **Katie Gamanji** (term: 1 year - start date: 5/12/2026 - 5/12/2027) [GB-appointed][alternate]
+* **Ricardo Aravena** (term: 1 year - start date: 5/12/2026 - 5/12/2027) [GB-appointed][alternate]
 
 Election [schedule](operations/election-schedule.md)
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The CNCF TOC is the technical governing body of the CNCF. It admits and oversees
 ## TOC Technical Vision
 The technical direction of the ecosystem is problem-centric. We encourage and support our projects to solve problems faced by adopters, to build the right ecosystem for innovation and embrace changes in the broader technical landscape. To exercise and increase the expertise within the technical community to compose solutions that stand the test of time.
 
-## Members
+## TOC Members
 
 * **Ahmed Bebars** (term: 2 years - start date: 5/12/2026 - 5/12/2028) [EndUser-appointed]
 * **Alex Chircop** (term: 2 years - start date: 3/4/2025 - 3/4/2027) [TOC-appointed]
@@ -27,6 +27,8 @@ The technical direction of the ecosystem is problem-centric. We encourage and su
 
 * **Katie Gamanji** (term: 1 year - start date: 5/12/2026 - 5/12/2027) [GB-appointed][alternate]
 * **Ricardo Aravena** (term: 1 year - start date: 5/12/2026 - 5/12/2027) [GB-appointed][alternate]
+
+Note: TOC Alternates are non-voting members of the TOC
 
 Election [schedule](operations/election-schedule.md)
 


### PR DESCRIPTION
The TOC collectively would like to rename the TOC shadows to TOC alternates as many times the elected person is already experienced. TOC Alternate more accurately describes the position.

If a TOC member needs to step down, the [TOC Alternate would step in](https://github.com/cncf/foundation/blob/32e2cbf223a57bf7b463a8dfd4db49e24dfbe6ef/charter.md?plain=1#L255) and is the most qualified person to do so.

ref: https://github.com/cncf/toc-private/issues/120