### PR TITLE
docs(template): governance DD chair hints from corpus

### DIFF
--- a/operations/toc-templates/template-dd-pr-graduation.md
+++ b/operations/toc-templates/template-dd-pr-graduation.md
@@ -63,6 +63,10 @@ Completion of this due diligence document, resolution of concerns raised, and pr
 
 Note: this section may be augmented by the completion of a Governance Review from the Project Reviews subproject.
 
+<!-- Chair: Link the Governance Review issue or merged `projects/$PROJECT/governance-review/` file in the DD header. Map review **Must-Fix** and **Areas for Improvement** to checkboxes using [governance-review-template.md](../toc_subprojects/project-reviews-subproject/governance-review-template.md). -->
+
+<!-- Chair: Under each (TOC Evaluation), use **Recommendation (non-blocking):** where appropriate; cite tracking issues or graduation follow-ups explicitly. -->
+
 ### Suggested
 
 - [ ]  **Governance has continuously been iterated upon by the project as a result of their experience applying it, with the governance history demonstrating evolution of maturity alongside the project's maturity evolution.**
@@ -109,7 +113,9 @@ Note: this section may be augmented by the completion of a Governance Review fro
 
 - [ ] **Project maintainers from at least 2 organizations that demonstrates survivability.**
 
-<!-- (TOC Evaluation goes here) --> 
+<!-- (TOC Evaluation goes here) -->
+
+<!-- Chair: Cite steering committee / MAINTAINERS affiliations across at least two organizations; optional metrics (e.g. LFX Insights, devstats). --> 
 
 - [ ] **Code and Doc ownership in Github and elsewhere matches documented governance roles.**
 

--- a/operations/toc-templates/template-dd-pr-incubation.md
+++ b/operations/toc-templates/template-dd-pr-incubation.md
@@ -61,6 +61,10 @@ Completion of this due diligence document, resolution of concerns raised, and pr
 
 Note: this section may be augmented by the completion of a Governance Review from the Project Reviews subproject.
 
+<!-- Chair: If `projects/$PROJECT/governance-review/` exists on [cncf/toc](https://github.com/cncf/toc) `main`, replace this note with "augmented by the Governance Review" and link the merged file. If absent, state the TOC assignee completes this section from the application issue and public governance artifacts (do not leave Required boxes empty). Map review sections to checkboxes using [governance-review-template.md](../toc_subprojects/project-reviews-subproject/governance-review-template.md). -->
+
+<!-- Chair: Under each (TOC Evaluation), use **Recommendation (non-blocking):** for incubation gaps; **Before graduation:** for items deferred to graduation; **Tracked under** &lt;issue URL&gt; when the project owns follow-up. -->
+
 ### Suggested
 
 - [ ] **Governance has continuously been iterated upon by the project as a result of their experience applying it, with the governance history demonstrating evolution of maturity alongside the project's maturity evolution.**
@@ -77,7 +81,9 @@ Note: this section may be augmented by the completion of a Governance Review fro
 
 - [ ] **Governance clearly documents [vendor-neutral](https://contribute.cncf.io/maintainers/community/vendor-neutrality/) of project direction.**
 
-<!-- (TOC Evaluation goes here) --> 
+<!-- (TOC Evaluation goes here) -->
+
+<!-- Chair: May cite neutral container image metadata (e.g. org.opencontainers.image.authors / project-collective MAINTAINER) vs single-vendor contact email in Dockerfiles. --> 
 
 - [ ] **Document how the project makes decisions on leadership, contribution acceptance, requests to the CNCF, and changes to governance or project goals.**
 


### PR DESCRIPTION
## Summary

Adds chair-facing HTML comments to the incubation and graduation DD templates under **Governance and Maintainers**, based on a corpus review of merged DDs (KServe, OpenFGA, wasmCloud, Crossplane, Knative).

- **Incubation:** Governance Review present vs absent; TOC evaluation prefixes (non-blocking, before graduation, tracked under); optional container image metadata note on vendor-neutral criterion.
- **Graduation:** Link Governance Review in header; map Must-Fix / Areas for Improvement; reminder before 2-organization maintainer survivability bullet.

## Test plan

- [ ] Chair comments render as expected in a draft DD fork PR
- [ ] No change to application templates