### PR TITLE
infra-lifecycle: copy writing from the Google Doc

### DIFF
--- a/tags/tag-infrastructure/initiatives/infrastructure-lifecycle/01_Executive_Summary.md
+++ b/tags/tag-infrastructure/initiatives/infrastructure-lifecycle/01_Executive_Summary.md
@@ -21,6 +21,6 @@ This brief provides an overview of the concepts, patterns,
 and practices that define effective infrastructure lifecycle management.
 It highlights common provisioning approaches, trade-offs, and practical use
 cases, as well as a snapshot of the tools that support these practices in the
-current Cloud Native Computing Foundation’ (CNCF) landscape. The intent is to
+current Cloud Native Computing Foundation’s (CNCF) landscape. The intent is to
 give operators an accessible perspective on how to manage infrastructure from
 creation to retirement.

--- a/tags/tag-infrastructure/initiatives/infrastructure-lifecycle/01_Executive_Summary.md
+++ b/tags/tag-infrastructure/initiatives/infrastructure-lifecycle/01_Executive_Summary.md
@@ -1,1 +1,26 @@
 # Executive Summary
+
+Infrastructure exists in a constant state of change. From provisioning
+new resources to scaling, applying updates, and decommissioning them, every
+stage of its lifecycle involves decisions, coordination, and repetitive actions.
+Traditionally, these tasks have required significant human intervention, which
+introduces variability, errors, and operational risk. Modern infrastructure
+lifecycle management addresses this by codifying the desired state of systems,
+automating repetitive work, and providing mechanisms to reconcile reality with
+intent.
+
+Effective lifecycle management is not just about automation. It is
+about creating a predictable process for the entire lifespan of a resource. By
+treating infrastructure as code and embracing patterns such as reconciliation
+loops, event-driven triggers, and declarative configuration, teams can
+continuously ensure that these resources are provisioned, maintained, and
+retired accordingly. This reduces operational toil, accelerates delivery, and
+improves reliability.
+
+This brief provides an overview of the concepts, patterns,
+and practices that define effective infrastructure lifecycle management.
+It highlights common provisioning approaches, trade-offs, and practical use
+cases, as well as a snapshot of the tools that support these practices in the
+current Cloud Native Computing Foundation’ (CNCF) landscape. The intent is to
+give operators an accessible perspective on how to manage infrastructure from
+creation to retirement.

--- a/tags/tag-infrastructure/initiatives/infrastructure-lifecycle/02_Introduction.md
+++ b/tags/tag-infrastructure/initiatives/infrastructure-lifecycle/02_Introduction.md
@@ -2,4 +2,18 @@
 
 ## Goal of this brief
 
+The goal of this brief is to provide a concise overview of infrastructure
+lifecycle management within the Cloud Native Computing Foundation (CNCF)
+landscape, highlighting relevant projects and key patterns and practices to help
+operators choose the right approach for their needs.
+
 ## Target Audience / Minimun Level of Experience
+
+This brief is intended for platform engineers, SREs, DevOps practitioners, and
+cloud architects who are responsible for designing, operating, or maintaining
+infrastructure. It is also relevant to engineers exploring lifecycle automation
+and infrastructure-as-code approaches. Readers are expected to have basic
+familiarity with cloud infrastructure concepts, provisioning patterns, and
+common automation tools, but no prior experience with lifecycle management is
+required.
+

--- a/tags/tag-infrastructure/initiatives/infrastructure-lifecycle/02_Introduction.md
+++ b/tags/tag-infrastructure/initiatives/infrastructure-lifecycle/02_Introduction.md
@@ -1,6 +1,6 @@
 # Introduction
 
-## Goal of this brief
+## Goal
 
 The goal of this brief is to provide a concise overview of infrastructure
 lifecycle management within the Cloud Native Computing Foundation (CNCF)

--- a/tags/tag-infrastructure/initiatives/infrastructure-lifecycle/03_Foundation.md
+++ b/tags/tag-infrastructure/initiatives/infrastructure-lifecycle/03_Foundation.md
@@ -1,13 +1,37 @@
 # Foundation
 
+Infrastructure lifecycle management relies on a set of foundational
+concepts that guide how resources are provisioned, updated, and decommissioned.
+At its core, the goal is to ensure that infrastructure behaves predictably over
+time.
+
 ## Infrastructure Provisioning Patterns
 
+When we think and talk about infrastructure provisioning patterns,
+we refer to the approaches used to create, maintain, update, and decommission
+resources throughout their lifecycle.
+
+While the implementation details vary across tools and platforms, the patterns
+we’ll cover in this brief share a common goal: to translate intent into
+reality in a repeatable and observable way. Some patterns focus on continuous
+reconciliation, where the system actively ensures that resources match the
+declared state. Others rely on event-driven triggers, responding dynamically to
+changes in the environment, while another approach uses a planned-apply model.
+Understanding these patterns helps operators choose the right approach for their
+infrastructure and workflows.
+
 ## Pattern Characteristics
+
+Each provisioning pattern has distinct characteristics that
+shape how it behaves in practice. These include how state is tracked, how
+changes are applied, and how the system responds to drift or external events.
+Some approaches continuously reconcile resources toward the desired state,
+offering strong alignment between intent and reality. Others execute updates
+in response to specific triggers, providing flexibility and responsiveness.
+Planned-apply models prioritize predictability and controlled change, allowing
+teams to review and approve updates before they take effect.
 
 ## Trade-offs
 
 ## Pattern Maturity
-
-
-
 

--- a/tags/tag-infrastructure/initiatives/infrastructure-lifecycle/05_Conclusion.md
+++ b/tags/tag-infrastructure/initiatives/infrastructure-lifecycle/05_Conclusion.md
@@ -1,9 +1,13 @@
 # Conclusion
 
 # Acknowledgements
-This brief is a community-driven effort by the CNCF TAG Infrastructure, with thanks to all who contributed, participated in discussions, and provided feedback.
+
+This brief is a community-driven effort by the CNCF TAG Infrastructure, with
+thanks to all who contributed, participated in discussions, and provided
+feedback.
 
 ## Contributors
+
 Bruno Schaatsbergen (@bschaatsbergen)
 Thomas Schuetz (@thschue)
 

--- a/tags/tag-infrastructure/initiatives/infrastructure-lifecycle/README.md
+++ b/tags/tag-infrastructure/initiatives/infrastructure-lifecycle/README.md
@@ -10,10 +10,9 @@ cloud-native principles. This framework will guide end-users in managing
 infrastructure to ensure it is secure, resilient, manageable, sustainable, and
 observable.
 
-Working has already begun on writing the whitepaper, as we are a Working Group
-under the TAG App Delivery We have progressed recently from the outline stage
-to the content stage as per TOC tech paper guideline, and would like to continue
-this work.
+Working has already begun on writing the whitepaper, We have progressed recently
+from the outline stage to the content stage as per TOC tech paper guideline, and
+would like to continue this work.
 
 ## Objective
 

--- a/tags/tag-infrastructure/initiatives/infrastructure-lifecycle/README.md
+++ b/tags/tag-infrastructure/initiatives/infrastructure-lifecycle/README.md
@@ -4,15 +4,25 @@ Creation issue: [#1631](https://github.com/cncf/toc/issues/1631)
 
 ## Description
 
-Develop a framework via a whitepaper for managing the lifecycle of infrastructure in public, private, or hybrid cloud environments based on cloud-native principles. This framework will guide end-users in managing infrastructure to ensure it is secure, resilient, manageable, sustainable, and observable.
+Develop a framework via a whitepaper for managing the lifecycle of
+infrastructure in public, private, or hybrid cloud environments based on
+cloud-native principles. This framework will guide end-users in managing
+infrastructure to ensure it is secure, resilient, manageable, sustainable, and
+observable.
 
-Working has already begun on writing the whitepaper, as we are a Working Group under the TAG App Delivery We have progressed recently from the outline stage to the content stage as per TOC tech paper guideline, and would like to continue this work.
+Working has already begun on writing the whitepaper, as we are a Working Group
+under the TAG App Delivery We have progressed recently from the outline stage
+to the content stage as per TOC tech paper guideline, and would like to continue
+this work.
 
 ## Objective
 
-Develop a framework for managing the lifecycle of infrastructure in public, private, or hybrid cloud environments through a whitepaper.
+Develop a framework for managing the lifecycle of infrastructure in public,
+private, or hybrid cloud environments through a whitepaper.
 
-Future deliverables could include a subproject for Infrastructure Lifecycle or additional initiatives that dig deeper into sub-categories such as Infrastructure-as-Code.
+Future deliverables could include a subproject for Infrastructure Lifecycle
+or additional initiatives that dig deeper into sub-categories such as
+Infrastructure-as-Code.
 
 ## Logistics
 


### PR DESCRIPTION
This brings across some of the initial writing from the Google doc we set up at kickoff. Further PRs will follow; the goal here is to create enough structure for others to start contributing