### PR TITLE
Add governance review for Meshery

### DIFF
--- a/projects/meshery/governance-review/2026-06-05.md
+++ b/projects/meshery/governance-review/2026-06-05.md
@@ -1,0 +1,241 @@
+# Governance Review for Meshery - 2026-06-05
+
+What follows is a governance review and assessment for the Meshery project. The
+review was completed as part of Meshery's Incubation application at CNCF.
+
+- Incubation application issue: https://github.com/cncf/toc/issues/1386
+- Governance review issue: https://github.com/cncf/toc/issues/2140
+- Project GitHub org: https://github.com/meshery
+- Project site: https://meshery.io/
+
+---
+
+## Summary and Assessment
+
+**Status:** Satisfactory
+
+### Executing the Assessment
+
+The assessment began with a broad review of the Meshery project and a review of the material in the [matriculation issue](https://github.com/cncf/toc/issues/1386) and in the project's own GitHub repositories and documentation. As the review was filled out several issues were discovered including <https://github.com/cncf/toc/issues/1386#issuecomment-4316066597>, <https://github.com/meshery/meshery/issues/19461>, and <https://github.com/meshery/meshery/issues/19447>, <https://github.com/meshery/meshery/issues/19460>. Following this, Kanva was separated from Meshery docs and a significant update was made to Meshery's [GOVERNANCE.md](https://github.com/meshery/meshery/blob/master/GOVERNANCE.md) in <https://github.com/meshery/meshery/pull/19772>. This review reflects those updates.
+
+### Must-Fix Items
+
+**The following issues have been identified that need to be resolved before
+Incubation:**
+
+* All governance-related issues were resolved in the course of the governance review.
+
+### Points of Excellence
+
+**The following aspects of governance are exemplary, and can be referenced as
+examples for other projects to copy:**
+
+* The project is a good example of CNCF's "[Maintainer Council](https://github.com/cncf/project-template/blob/main/GOVERNANCE-maintainer.md)" style of governance. There are actually several maintainer sets, one for each core subproject, and all are part of the overarching council. A single weekly meeting brings all these groups together.
+* The project has an innovative certification program described at <https://github.com/meshery/meshery/blob/master/GOVERNANCE.md#certified-meshery-contributor-cmc> that helps contributors vet and prove their knowledge.
+
+### Areas for Improvement
+
+**Over the next year, the project should work on the following issues to improve
+its governance, these are considered non-blocking:**
+
+* Develop an official list of core and extension subprojects with a label describing their maturity.
+
+---
+
+## Review
+
+### Summary
+
+Meshery provides an interface for a) managing existing resources in Kubernetes and b) designing new composite resource types ("Designs") to be deployed and monitored by Kubernetes. Meshery includes many extension points that enable adding new resource types for use in compositions as well as identity providers and other additional functionality.
+
+Kanva is a Meshery UI extension for creating compositions using a visual interface. It is no longer a core part of Meshery but could be a valuable addition to an installation.
+
+Meshery's core implementation is managed in the github.com/meshery organization and public extensions are maintained in the github.com/meshery-extensions repo.
+
+
+### Governance Evolution
+
+**Governance has continuously been iterated upon by the project as a result of
+their experience applying it, with the governance history demonstrating
+evolution of maturity alongside the project's maturity evolution.**
+**Incubating:** Suggested | **Graduated:** Suggested
+
+- The GOVERNANCE doc has been updated over time as listed at <https://github.com/meshery/meshery/commits/master/GOVERNANCE.md>. A significant update happened in <https://github.com/meshery/meshery/pull/19772> to use CNCF's project templates.
+- Examples of changes: <https://github.com/meshery/meshery/pull/12162>, <https://github.com/meshery/meshery/pull/7968>, <https://github.com/meshery/meshery/pull/4992>
+- As part of matriculation governance reviews additional changes were applied in: <https://github.com/meshery/meshery/issues/19461>, <https://github.com/meshery/meshery/issues/19447>, <https://github.com/meshery/meshery/issues/19460>
+
+### Discoverability
+
+**Clear and discoverable project governance documentation.**
+**Incubating:** Suggested | **Graduated:** Required
+
+The project's [GOVERNANCE doc](https://github.com/meshery/meshery/blob/master/GOVERNANCE.md) describes all aspects of project and subproject governance.
+
+### Accuracy and Clarity
+
+**Governance is up to date with actual project activities, including any
+meetings, elections, leadership, or approval processes.**
+**Incubating:** Suggested | **Graduated:** Required
+
+- Nominations and votes are discoverable in the meshery.io Google Group at <https://groups.google.com/a/meshery.io/g/maintainers/search?q=vote>. Maintainers are added via PRs to [MAINTAINERS.md](https://github.com/meshery/meshery/blob/master/MAINTAINERS.md), for example:
+    - <https://github.com/meshery/meshery/pull/14886>
+    - <https://github.com/meshery/meshery/pull/16359>
+    - <https://github.com/meshery/meshery/pull/15092>
+    - <https://github.com/meshery/meshery/pull/14160>
+    - <https://github.com/meshery/meshery/pull/12167>
+- Meetings are held weekly where decisions are made, notes at <https://docs.google.com/document/d/15IEwtTxPOkQXN2r_1LzGXuAv2mIUlmbdtmxpyxXF-KI>
+
+**Governance clearly documents [vendor-neutrality] of project direction.**
+**Incubating:** Suggested | **Graduated:** Required
+
+Yes, <https://github.com/meshery/meshery/blob/master/GOVERNANCE.md#vendor-neutrality>.
+
+
+### Decisions and Role Assignments
+
+**Document how the project makes decisions on leadership roles, contribution
+acceptance, requests to the CNCF, and changes to governance or project goals.**
+**Incubating:** Suggested | **Graduated:** Required
+
+According to [GOVERNANCE.md](https://github.com/meshery/meshery/blob/master/GOVERNANCE.md#how-specific-kinds-of-decisions-are-made):
+
+> * **Leadership roles**. Maintainers are added and removed through the Maintainer Lifecycle. Organization membership is granted per the Organization Member requirements. Subproject Leads are selected by their subproject's Maintainers.
+> * **Acceptance of contributions**. A change is accepted when it meets the project's quality standards and receives approval from the maintainers responsible for the affected code or documentation, as recorded in MAINTAINERS.md. Anyone may review and comment; approval authority rests with those maintainers.
+> * **Requests to the CNCF**. Handled per Requesting CNCF Resources.
+> * **Changes to governance or project goals**. Handled per Changes to This Governance, by a 2/3 vote of the Maintainer Council.
+
+**Document how role, function-based members, or sub-teams are assigned,
+onboarded, and removed for specific teams (example: Security Response
+Committee).**
+**Incubating:** Suggested | **Graduated:** Required
+
+For security response a special team and email address `security@meshery.dev` is used as described in <https://github.com/meshery/meshery/blob/master/GOVERNANCE.md#security-response>.
+
+Extension subprojects are governed as described in <https://github.com/meshery/meshery/blob/master/GOVERNANCE.md#extensions-maintainers>.
+
+Contribution guides for each of about 15 domains are available at https://docs.meshery.io/project/contributing/.
+
+### Maintainers and Maintainer Lifecycle
+
+**Document a complete maintainer lifecycle process (including roles, onboarding,
+offboarding, and emeritus status).**
+**Incubating:** Suggested | **Graduated:** Required
+
+Contributors may become Organization Members and then Maintainers by following the processes in GOVERNANCE.md at <https://github.com/meshery/meshery/blob/master/GOVERNANCE.md#roles-and-the-contributor-ladder>.
+
+**Demonstrate usage of the maintainer lifecycle with outcomes, either through
+the addition or replacement of maintainers as project events have required.**
+**Incubating:** Suggested | **Graduated:** Required
+
+Maintainers have been added and removed according to the history at <https://github.com/meshery/meshery/commits/master/MAINTAINERS.md>.
+
+
+**Document complete list of current maintainers, including names, contact
+information, domain of responsibility, and affiliation.**
+**Incubating:** Required | **Graduated:** Required
+
+These are available in <https://github.com/meshery/meshery/blob/master/MAINTAINERS.md>.
+
+**A number of active maintainers which is appropriate to the size and scope of
+the project.**
+**Incubating:** Required | **Graduated:** Required
+
+There are at least 3 maintainers for every domain in the core project as documented in <https://github.com/meshery/meshery/blob/master/MAINTAINERS.md>.
+
+
+**Project maintainers from at least 2 organizations that demonstrates
+survivability.**
+**Incubating:** N/A | **Graduated:** Required
+
+Maintainers in <https://github.com/meshery/meshery/blob/master/MAINTAINERS.md> come from many organizations.
+
+
+
+### Ownership
+
+**Code and Doc ownership in Github and elsewhere matches documented governance
+roles.**
+**Incubating:** Required | **Graduated:** Required
+
+Ownership is governed by GitHub groups whose membership correlates with the lists in MAINTAINERS.md, as described at <https://github.com/meshery/meshery/blob/master/GOVERNANCE.md#systems-access-and-repository-permissions>.
+
+### Code of Conduct
+
+**Document adoption and adherence to the CNCF Code of Conduct or the project's
+CoC which is based off the CNCF CoC and not in conflict with it.**
+**Incubating:** Required | **Graduated:** Required
+
+<https://github.com/meshery/meshery/blob/master/GOVERNANCE.md#code-of-conduct>
+
+**CNCF Code of Conduct is cross-linked from other governance documents.**
+**Incubating:** Required | **Graduated:** Required
+
+Yes
+
+
+### Subprojects
+
+**All subprojects, if any, are listed.**
+**Incubating:** Required | **Graduated:** Required
+
+Core subprojects are listed in <https://github.com/meshery/meshery/blob/master/GOVERNANCE.md#subprojects-and-domains>. There is also a list in <https://github.com/meshery/meshery/blob/master/MAINTAINERS.md>.
+
+Meshery also has extensions, which are treated differently than core subprojects. It seems that extensions are listed at <https://github.com/meshery/meshery/blob/master/MAINTAINERS.md#extensions-maintainers-meshery-extensions>.
+
+
+**If the project has subprojects: subproject leadership, contribution, maturity
+status documented, including add/remove process.**
+**Incubating:** Suggested | **Graduated:** Required
+
+Subproject governance and lifecycle are documented in <https://github.com/meshery/meshery/blob/master/GOVERNANCE.md#subproject-lifecycle>
+
+Extension governance is documented in <https://github.com/meshery/meshery/blob/master/GOVERNANCE.md#extensions-githubcommeshery-extensions>.
+
+### Contributors and Community
+
+**Contributor ladder with multiple roles for contributors.**
+**Incubating:** Suggested | **Graduated:** Suggested
+
+As documented in <https://github.com/meshery/meshery/blob/master/GOVERNANCE.md#roles-and-the-contributor-ladder> the project provides several levels and different roles for contributors.
+
+**Clearly defined and discoverable process to submit issues or changes.**
+**Incubating:** Required | **Graduated:** Required
+
+<https://github.com/meshery/meshery/blob/master/GOVERNANCE.md#how-to-contribute>
+
+**Project must have, and document, at least one public communications channel
+for users and/or contributors.**
+**Incubating:** Required | **Graduated:** Required
+
+<https://github.com/meshery/meshery/blob/master/GOVERNANCE.md#communication-channels>
+
+**List and document all project communication channels, including subprojects
+(mail list/slack/etc.). List any non-public communications channels and what
+their special purpose is.**
+**Incubating:** Required | **Graduated:** Required
+
+<https://github.com/meshery/meshery/blob/master/GOVERNANCE.md#communication-channels>
+
+**Up-to-date public meeting schedulers and/or integration with CNCF calendar.**
+**Incubating:** Required | **Graduated:** Required
+
+- <https://github.com/meshery/meshery/blob/master/GOVERNANCE.md#meetings>
+- <https://meshery.io/calendar>
+
+**Documentation of how to contribute, with increasing detail as the project
+matures.**
+**Incubating:** Required | **Graduated:** Required
+
+<https://github.com/meshery/meshery/blob/master/GOVERNANCE.md#how-to-contribute>
+
+
+**Demonstrate contributor activity and recruitment.**
+**Incubating:** Required | **Graduated:** Required
+
+- https://github.com/meshery/meshery/graphs/contributors
+- https://github.com/meshery/meshery/blob/master/GOVERNANCE.md#recognition-and-certification
+- https://insights.linuxfoundation.org/project/meshery
+
+
+[project milestone or other requirement]: https://github.com/cncf/toc/tree/main/process#how-to-apply-to-move-levels
+[vendor-neutrality]: https://contribute.cncf.io/maintainers/community/vendor-neutrality/


### PR DESCRIPTION
Governance review for Meshery project, based on CNCF TOC template and evidence submitted by project leads.

Closes #2140 