### PR TITLE
Clarify GTR snapshot location and naming convention

### DIFF
--- a/operations/dd-toc-guide.md
+++ b/operations/dd-toc-guide.md
@@ -65,7 +65,7 @@ All TOC members are expected to assist in the triaging of project applications t
 This light-weight triage/evaluation must cover the list below (it is not exhaustive and is a minimum triage set from the [incubation template retrieved 12 DEC 2025](https://github.com/cncf/toc/blob/c2943ffc98064dd88e9ef9c4afd5a8856898942f/.github/ISSUE_TEMPLATE/template-incubation-application.md)):
 * Adoption Assertion includes the Adopters file link, and the project has an entry in the Adopter's form responses to provide 5-7 adopters to reach out to. [Check here](https://github.com/cncf/toc/blob/main/FAQ.md#what-is-the-definition-of-an-adopter) for the definition of an Adopter.
 * Application Process Principles provides 
-  * link to a completed [General Technical Review (GTR)](../toc_subprojects/project-reviews-subproject/general-technical-questions.md)
+  * link to a completed [General Technical Review (GTR)](../toc_subprojects/project-reviews-subproject/general-technical-questions.md). The GTR snapshot should be submitted as a PR into `projects/<project-name>/tech-review/` in this repo, named `YYYY-MM-DD.md` to reflect the date of the snapshot. Projects may maintain a working copy in their own repository, but the TOC repo entry is the required artifact for the DD.
   * link to a completed [Governance Review](../toc_subprojects/project-reviews-subproject/governance-review-template.md)
   * (optional) link to a technical presentation to a CNCF TAG, or links to notes or issues about such a presentation
   * assertion of vendor neutrality

--- a/operations/toc-templates/template-dd-pr-graduation.md
+++ b/operations/toc-templates/template-dd-pr-graduation.md
@@ -33,7 +33,7 @@ _[The TOC has found the project to have satisfied the criteria for $LEVEL/ The T
 
 
 - [ ] **Complete a [General Technical Review (GTR)](../toc_subprojects/project-reviews-subproject/general-technical-questions.md).**
-  - This was most recently revised on DD-MMM-YYYY and can be discovered at $LINK.
+  - This was most recently revised on DD-MMM-YYYY. The snapshot is available in this repo at `projects/$PROJECT/tech-review/YYYY-MM-DD.md` ($LINK).
 
 <!-- (Project assertion goes here) --> 
 

--- a/operations/toc-templates/template-dd-pr-incubation.md
+++ b/operations/toc-templates/template-dd-pr-incubation.md
@@ -31,7 +31,7 @@ _[The TOC has found the project to have satisfied the criteria for $LEVEL/ The T
 
 
 - [ ] **Complete a [General Technical Review (GTR)](../toc_subprojects/project-reviews-subproject/general-technical-questions.md).**
-  - This was most recently revised on DD-MMM-YYYY and can be discovered at $LINK.
+  - This was most recently revised on DD-MMM-YYYY. The snapshot is available in this repo at `projects/$PROJECT/tech-review/YYYY-MM-DD.md` ($LINK).
 
 <!-- (Project assertion goes here) --> 
 


### PR DESCRIPTION
Updates the DD guide and both DD PR templates to clarify that the GTR snapshot should be submitted as a PR into projects/<project-name>/tech-review/YYYY-MM-DD.md in the TOC repo. Prompted by the Kubeflow GTR PR going through multiple hurdles due to unclear instructions.