### PR TITLE
Add publication labels and commands for blog and tech-paper

### DIFF
--- a/.github/README_Labelling.md
+++ b/.github/README_Labelling.md
@@ -18,13 +18,16 @@ Use slash commands in a normal issue/PR comment to apply or remove labels.
 #### Core triage/grouping
 
 - `/kind <value>`
-  - values: `dd`, `docs`, `enhancement`, `initiative`, `meeting`, `review`, `subproject`
+  - values: `dd`, `docs`, `enhancement`, `initiative`, `meeting`, `publication`, `review`, `subproject`
 - `/triage <value>`
   - values: `valid`, `needs-information`, `duplicate`, `not-planned`
 - `/tag <value>`
   - values: `developer-experience`, `infrastructure`, `operational-resilience`, `security-and-compliance`, `workloads-foundation`
 - `/sub <value>`
   - values: `contributor-strategy-and-advocacy`, `mentoring`, `project-reviews`
+- `/pub <value>`
+  - values: `blog`, `tech-paper`
+  - applying one removes any other `pub/*` label (mutually exclusive)
 - `/toc`
 - `/level <value>`
   - values: `archived`, `graduation`, `incubation`, `sandbox`
@@ -61,6 +64,7 @@ Use slash commands in a normal issue/PR comment to apply or remove labels.
 - `/remove-triage <value>`
 - `/remove-tag <value>`
 - `/remove-sub <value>`
+- `/remove-pub <value>`
 - `/remove-toc`
 - `/remove-toc/initiative <value>`
 - `/remove-init <value>`
@@ -100,6 +104,7 @@ The following label groups enforce mutual exclusivity automatically. When a labe
 |---|---|
 | `contribution-agreement` | `contribution-agreement/signed` ↔ removes `contribution-agreement/unsigned` (and vice versa) |
 | `level/*` | `level/archived`, `level/graduation`, `level/incubation`, `level/sandbox` — applying one removes the others |
+| `pub/*` | `pub/blog`, `pub/tech-paper` — applying one removes the others |
 | `triage/*` | Enforced via `/triage` command |
 | `kind/*` | Enforced via `/kind` command |
 | `dd/status/*` | Enforced via `/dd/status` command |

--- a/.github/labels.yaml
+++ b/.github/labels.yaml
@@ -122,6 +122,9 @@ labels:
 - name: kind/meeting
   description: Item related to a meeting
   color: 8250DF
+- name: kind/publication
+  description: Item related to a publication (blog, tech-paper, etc.)
+  color: 8250DF
 - name: kind/review
   description: Item related to a governance, tech, or other review
   color: 8250DF
@@ -149,6 +152,12 @@ labels:
 - name: needs-triage
   description: Indicates an issue or PR that has not been triaged yet (has a 'triage/foo' label applied)
   color: FBCA04
+- name: pub/blog
+  description: Blog post publication
+  color: B57614
+- name: pub/tech-paper
+  description: Technical paper / whitepaper publication
+  color: B57614
 - name: review/governance
   description: Project Governance Review
   color: '5319e7'
@@ -271,6 +280,15 @@ ruleset:
   - kind: remove-label
     spec: 
       match: level/{{ argv.0 }}
+
+- name: remove-pub
+  kind: match
+  spec:
+    command: /remove-pub
+  actions:
+  - kind: remove-label
+    spec:
+      match: pub/{{ argv.0 }}
 
 - name: apply-level
   kind: match
@@ -452,6 +470,7 @@ ruleset:
       - kind/enhancement
       - kind/initiative
       - kind/meeting
+      - kind/publication
       - kind/review
       - kind/subproject
   actions:
@@ -540,6 +559,22 @@ ruleset:
   - kind: apply-label
     spec:
       label: sub/{{ argv.0 }}
+
+- name: apply-pub
+  kind: match
+  spec:
+    command: /pub
+    rules:
+    - matchList:
+      - pub/blog
+      - pub/tech-paper
+  actions:
+  - kind: remove-label
+    spec:
+      match: pub/*
+  - kind: apply-label
+    spec:
+      label: pub/{{ argv.0 }}
 
 
 - name: remove-dd-needs-triage


### PR DESCRIPTION
## Summary

Adds a new `kind/publication` label and a new `pub/*` namespace (`pub/blog`, `pub/tech-paper`) for tracking publication artifacts (blog posts, technical papers, etc.).

## Changes

**`.github/labels.yaml`**
- New label: `kind/publication` (color `8250DF`, consistent with other `kind/*`)
- New labels: `pub/blog`, `pub/tech-paper` (color `B57614`)
- New `/pub <value>` slash command (mutually exclusive — applying one `pub/*` removes the others)
- New `/remove-pub <value>` slash command
- `kind/publication` added to the `/kind` command's allowed values

**`.github/README_Labelling.md`**
- Documented `publication` under `/kind` values
- Documented new `/pub` and `/remove-pub` commands
- Added `pub/*` to the mutual-exclusivity table

## Design notes

- `pub/*` is a new namespace (not nested under `kind/*`) to keep all `kind/*` labels single-level and consistent.
- `kind/publication` and `pub/*` are independent: `kind/*` answers "what is this issue about?", `pub/*` answers "what publication type?". Users apply both explicitly.
- `pub/*` is **not** treated as a group — publication issues still need a `toc`/`tag/*`/`sub/*` owner, so `needs-group` behavior is unchanged.