### PR TITLE
docs: Add TOC mentoring subproject charter

### DIFF
--- a/tags.yaml
+++ b/tags.yaml
@@ -624,27 +624,27 @@ toc_subprojects: # TOC SubProjects
     subproject_initiatives: https://github.com/cncf/toc/issues?q=state%3Aopen%20label%3Atoc%2Fcontributor-strategy-and-advocacy-subproject%20label%3Akind%2Finitiative
   - dir: mentoring-subproject # Mentoring SubProject
     name: Mentoring SubProject
-    mission_statement: Foo-Baz-Bar
+    mission_statement: Provide a community-governed home for CNCF mentorship programs and help CNCF projects grow sustainable contributor pathways through experienced mentorship.
     charter_link: charter.md
     label: mentoring-subproject
     leadership:
       chairs:
+        - github: bupd
+          lfx_id: bupd
+          name: Prasanth Baskar
+          company: 8gears
+          email: bupdprasanth@gmail.com
         - github: nate-double-u
           lfx_id: natewaddington
           name: Nate Waddington
           company: The Linux Foundation
           email: nwaddington@linuxfoundation.org
-  #      - github: foo
-  #        lfx_id: baz
-  #        name: Foo Baz Bar
-  #        company: Foo Baz Bar co.
-  #        email: me@foobazbar.org
-  #    tech_leads:
-  #      - github: foo
-  #        lfx_id: baz
-  #        name: Foo Baz Bar
-  #        company: Foo Baz Bar co.
-  #        email: me@foobazbar.org
+      tech_leads:
+        - github: Cali0707
+          lfx_id: Cali0707
+          name: Calum Murray
+          company: Red Hat
+          email: cmurray@redhat.com
   #      - github: foo
   #        lfx_id: baz
   #        name: Foo Baz Bar

--- a/toc_subprojects/mentoring-subproject/README.md
+++ b/toc_subprojects/mentoring-subproject/README.md
@@ -3,13 +3,16 @@
 <!-- THIS FILE IS AUTO-GENERATED FROM /tags.yaml -->
 
 ## Mission Statement
-Foo-Baz-Bar
+Provide a community-governed home for CNCF mentorship programs and help CNCF projects grow sustainable contributor pathways through experienced mentorship.
 
 [Charter](./charter.md)
 
 ## Leadership
 ### Chairs
+- Prasanth Baskar (**[@bupd](https://github.com/bupd)**), 8gears
 - Nate Waddington (**[@nate-double-u](https://github.com/nate-double-u)**), The Linux Foundation
+### Tech Leads
+- Calum Murray (**[@Cali0707](https://github.com/Cali0707)**), Red Hat
 
 ## Meetings
 - **Mentoring SubProject Meetings**: [Calendar](https://zoom-lfx.platform.linuxfoundation.org/meetings/toc-mentoring-subproject?view=list) | [Recordings](https://www.youtube.com/@CNCFTOCMentoringSubProject)

--- a/toc_subprojects/mentoring-subproject/charter.md
+++ b/toc_subprojects/mentoring-subproject/charter.md
@@ -1,1 +1,51 @@
-Charter content here
+# CNCF Mentoring SubProject Charter
+
+## Mission
+
+The CNCF Mentoring SubProject provides a community-governed home for CNCF mentorship programs and helps CNCF projects grow sustainable contributor pathways through experienced mentorship.
+
+The subproject brings together CNCF projects, mentors, mentees, and program administrators to coordinate mentorship programs, maintain shared guidance, and improve the quality and consistency of mentoring across the CNCF ecosystem.
+
+## Scope
+
+### In Scope
+
+To support CNCF mentorship programs, the Mentoring SubProject coordinates:
+
+- The CNCF portion of LFX Mentorship.
+- Google Summer of Code.
+- Google Season of Docs.
+- Outreachy.
+- Other mentorship initiatives approved through the subproject's governance.
+
+The subproject also supports the following mentoring practices:
+
+- Mentorship opportunities for code, documentation, community, design, research, and other non-code contribution areas.
+- Guidance for CNCF projects that want to participate in mentorship programs.
+- Guidance for mentors, mentees, project maintainers, and program administrators.
+- Contributor pathways that help mentees remain involved in CNCF projects and become future mentors.
+- Community practices that improve diversity among mentors and mentees.
+
+The subproject owns and maintains:
+
+- The [cncf/mentoring](https://github.com/cncf/mentoring) repository.
+- CNCF mentoring documentation and program guidance.
+- CNCF mentoring pages on [contribute.cncf.io](https://contribute.cncf.io).
+- CNCF accounts and administrative access for mentorship initiatives managed by the subproject.
+
+### Out of Scope
+
+- Replacing project maintainers as the owners of project-specific mentorship ideas, tasks, or technical review.
+- Guaranteeing mentor or mentee placement for every program cycle.
+- Operating as a general contributor support forum outside mentoring-related workflows.
+- Owning CNCF project governance, maintainership decisions, or contributor promotion paths beyond mentoring guidance.
+- Running mentorship programs that do not involve CNCF projects, contributors, or community goals.
+
+## Deliverables
+
+- **Program coordination** — ongoing coordination for CNCF participation in LFX Mentorship, Google Summer of Code, Google Season of Docs, Outreachy, and similar initiatives.
+- **Mentoring guidance** — maintained guidance for mentors, mentees, project maintainers, and program administrators.
+- **Reusable templates** — templates for project ideas, mentee applications, mentor onboarding, and program reporting.
+- **Documentation and website updates** — improvements to [cncf/mentoring](https://github.com/cncf/mentoring), [mentoring.cncf.io](https://mentoring.cncf.io), and mentoring content on [contribute.cncf.io](https://contribute.cncf.io).
+- **Mentorship recommendations** — recommendations for increasing both code and non-code mentorship opportunities across CNCF projects.
+- **Program reporting** — reporting on mentoring participation, outcomes, and follow-up paths where appropriate.


### PR DESCRIPTION
## Summary
Add the TOC Mentoring SubProject charter and updates the metadata.

## Changes 
- Replace the placeholder in Mentoring SubProject charter with misson, scope, out-of-scope items, and deliverables
- Update `tags.yaml` with the Mentoring SubProject mission statement and leadership.
- Regenerated the Mentoring SubProject README from `tags.yaml`

cc ./ @nate-double-u , @Cali0707 