### PR TITLE
docs(mentoring): Add Mentoring Subproject charter

### DIFF
--- a/toc_subprojects/mentoring-subproject/charter.md
+++ b/toc_subprojects/mentoring-subproject/charter.md
@@ -1,1 +1,50 @@
-Charter content here
+# CNCF Mentoring SubProject Charter
+
+## Introduction
+
+The CNCF participates in and runs several mentorship programs throughout the year. These mentoring initiatives should be administered by, and be accountable to, the wider CNCF community.
+
+## Mission
+
+The Mentoring SubProject:
+
+- Encourages cloud native computing adoption by providing opportunities for a diverse group of new contributors to work on CNCF projects with experienced mentorship.
+- Promotes growth and sustainability of projects through mentoring new and existing contributors.
+- Provides support and advice to CNCF projects around mentorship initiatives.
+
+## Goals
+
+- Increase CNCF project participation in mentoring programs external to the Linux Foundation.
+- Increase the number of CNCF projects and mentee participation in the LFX Mentorship program.
+- Increase the quality of mentorship that CNCF projects provide across all mentorship initiatives.
+- Explore opportunities for CNCF participation in new mentorship initiatives.
+- Diversity in participants, both mentees and mentors.
+- Increase both code and non-code mentorship opportunities.
+- Develop mentorship:
+  - Provide a path for mentees to become mentors.
+  - Provide education for mentors.
+
+## Scope and Ownership
+
+The Mentoring SubProject manages the following mentorship initiatives:
+
+- The CNCF portion of LFX Mentorship.
+- Google Summer of Code.
+- Google Season of Docs.
+- Outreachy.
+- Other initiatives as desired.
+
+The Mentoring SubProject owns and maintains the following resources:
+
+- The [cncf/mentoring](https://github.com/cncf/mentoring) repository.
+- Mentoring documentation and program guidance in the [cncf/mentoring](https://github.com/cncf/mentoring) repository.
+- Any pages in [contribute.cncf.io](https://contribute.cncf.io) about mentoring.
+- CNCF accounts for the above mentoring initiatives.
+
+## Documentation
+
+Official documentation is organized and published in the [cncf/mentoring](https://github.com/cncf/mentoring) repository.
+
+## Facilitators
+
+- Nate Waddington ([@nate-double-u](https://github.com/nate-double-u)), CNCF


### PR DESCRIPTION
## Summary
Add Mentoring Subproject charter 

The TOC Mentoring Subproject charter is based on the previous CNCF Mentoring that lived under TAG CS in https://github.com/cncf/tag-contributor-strategy/blob/main/mentoring/README.md 

## Todo
- [ ] Create Mailing List for TOC Mentoring Subproject 