### PR TITLE
docs(operations): add post-graduation health check template

### DIFF
--- a/operations/post-graduation-health-check-template.md
+++ b/operations/post-graduation-health-check-template.md
@@ -1,0 +1,129 @@
+# Post-Graduation Health Check Template
+
+**Purpose:** Annual health check for graduated CNCF projects to verify that governance diversity, community health, and security posture are sustained after graduation. The TOC's governance analysis found that 7 of 35 graduated projects (20%) show post-graduation governance concentration — all 7 would have been caught with regular monitoring.
+
+**Frequency:** Annual, or triggered by signals (maintainer org changes, LFX health score drop, community reports)
+
+**Owner:** TOC, with support from the Project Reviews Subproject
+
+---
+
+## Project Information
+
+| Field | Value |
+| :--- | :--- |
+| Project name | |
+| Level | Graduated |
+| Graduation date | |
+| Last health check | |
+| TOC reviewer | |
+| Date of this review | |
+
+---
+
+## 1. Governance Diversity
+
+| Check | Current | At Graduation | Trend |
+| :--- | :--- | :--- | :--- |
+| LFX org dependency % | | | ↑ ↓ → |
+| Number of active maintainer orgs | | | |
+| Org-balance mechanism in place | Yes / No | | |
+| Steering committee / governance body active | Yes / No | | |
+| Governance meetings held in last 12 months | | | |
+| Non-dominant-org maintainers added since graduation | | | |
+| Emeritus process applied in last 12 months | Yes / No | | |
+
+**Flags:**
+- [ ] LFX org dependency increased by >10% since graduation
+- [ ] Number of active maintainer orgs decreased
+- [ ] Org-balance mechanism removed or not enforced
+- [ ] No governance meetings held in 12 months
+- [ ] MAINTAINERS file has inactive members not moved to emeritus
+
+---
+
+## 2. Community Health
+
+| Check | Current | At Graduation | Trend |
+| :--- | :--- | :--- | :--- |
+| Active contributors (LFX, 365d) | | | ↑ ↓ → |
+| Active orgs (LFX, 365d) | | | |
+| LFX health score | | | |
+| GitHub stars (365d) | | | |
+| Commit trend (quarterly) | | | |
+| Open issues | | | |
+| Release cadence | | | |
+| Last release date | | | |
+
+**Flags:**
+- [ ] LFX health score dropped below 70
+- [ ] Active contributors declined >25% YoY
+- [ ] No release in 6+ months
+- [ ] Commit activity declining for 3+ consecutive quarters
+
+---
+
+## 3. Security Posture
+
+| Check | Status |
+| :--- | :--- |
+| SECURITY.md current and discoverable | Yes / No |
+| Security response team members current | Yes / No |
+| Security contacts use project email (not single-vendor) | Yes / No |
+| OpenSSF Best Practices badge current | Passing / Silver / Gold |
+| GitHub Security Advisories enabled | Yes / No |
+| CVEs addressed in last 12 months | |
+| Last security advisory published | |
+
+**Flags:**
+- [ ] All security contacts from one organization
+- [ ] OpenSSF badge lapsed or dropped level
+- [ ] No security advisory process activity in 12 months
+
+---
+
+## 4. Vendor Neutrality
+
+| Check | Status |
+| :--- | :--- |
+| Project website links to all commercial vendors equally | Yes / No |
+| Communication channels are project-owned (not vendor-owned) | Yes / No |
+| Project events give equal vendor access | Yes / No |
+| No single vendor branding dominates project assets | Yes / No |
+
+**Flags:**
+- [ ] Website links to single vendor's commercial product page
+- [ ] All security/admin contacts use one company's email domain
+- [ ] Project events hosted exclusively at one vendor's office
+
+---
+
+## 5. Assessment
+
+| Classification | Criteria |
+| :--- | :--- |
+| **Healthy** | No flags. Diversity sustained or improving. |
+| **Watch** | 1-2 flags. Trend is concerning but not critical. Follow up in 6 months. |
+| **At-risk** | 3+ flags, or org dependency increased significantly. Engage project maintainers. |
+| **Critical** | Governance concentration at levels that threaten project independence. Escalate to full TOC. |
+
+**This project's classification:** _____________
+
+---
+
+## 6. Recommendations
+
+_TOC reviewer fills in specific recommendations based on findings._
+
+1. 
+2. 
+3. 
+
+---
+
+## 7. Follow-up
+
+| Action | Owner | Due |
+| :--- | :--- | :--- |
+| | | |
+| Next health check scheduled | | |


### PR DESCRIPTION
## Summary

Adds a structured template for annual health checks on graduated CNCF projects. Placed in operations/ alongside other TOC operational templates.

## Why

The TOC governance analysis of 71 graduated and incubating projects found that 7 of 35 graduated projects (20%) show post-graduation governance concentration. All 7 would have been caught with regular monitoring. No template or process currently exists for this monitoring.

## What the template covers

- **Governance diversity** — LFX org dependency trend, maintainer org count, org-balance mechanism status, governance meeting activity, emeritus enforcement
- **Community health** — contributor/org trends, health score, commit activity, release cadence
- **Security posture** — SECURITY.md currency, response team membership, OpenSSF badge status, advisory activity
- **Vendor neutrality** — website links, communication channels, event access, branding

## Classification system

- **Healthy** — no flags, diversity sustained or improving
- **Watch** — 1-2 flags, follow up in 6 months
- **At-risk** — 3+ flags, engage project maintainers
- **Critical** — governance concentration threatens independence, escalate to full TOC

## Related

- [Governance best practices PR](https://github.com/cncf/toc/pull/2224) (best practice #25 recommends post-graduation health checks)
- [Project template updates PR](https://github.com/cncf/project-template/pull/50) (security response team and succession plan templates)

Signed-off-by: Karena Angell <karena.angell@gmail.com>