### PR TITLE
docs(infralifecycle): note in-progress sections tracked in #1631

### DIFF
--- a/tags/tag-infrastructure/initiatives/infrastructure-lifecycle/03_Foundation.md
+++ b/tags/tag-infrastructure/initiatives/infrastructure-lifecycle/03_Foundation.md
@@ -51,6 +51,11 @@ On-demand operations can also be more complex than a continuously reconciled one
 
 In different terms, this can be described as “push versus pull” or “pipelines” versus "controllers". Neither model is wrong, and both have their benefits and disadvantages. There is also the option to go for a hybrid approach, where certain parts of the system are reconciled continuously, while others are not.
 
+_The remaining sections below (DSL vs. Programming Language, Stateful vs.
+Stateless, Trade-offs, Pattern Maturity) are still in progress, drafted
+collaboratively outside this repo. Tracked in
+[#1631](https://github.com/cncf/toc/issues/1631)._
+
 ## DSL vs. Programming Language
 
 ## Stateful vs. Stateless

--- a/tags/tag-infrastructure/initiatives/infrastructure-lifecycle/05_Conclusion.md
+++ b/tags/tag-infrastructure/initiatives/infrastructure-lifecycle/05_Conclusion.md
@@ -1,5 +1,7 @@
 # Conclusion
 
+_Work in progress, drafted collaboratively outside this repo. Tracked in [#1631](https://github.com/cncf/toc/issues/1631)._
+
 # Acknowledgements
 
 This brief is a community-driven effort by the CNCF TAG Infrastructure, with


### PR DESCRIPTION
Marks the sections of the infrastructure lifecycle whitepaper that are still being drafted collaboratively outside this repo (DSL vs. Programming Language, Stateful vs. Stateless, Trade-offs, Pattern Maturity, Conclusion), so contributors don't duplicate work already in progress. Tracked in #1631.