### PR TITLE
Add Dragonfly to I/O bottlenecks in AI Scheduling Challenges whitepaper

### DIFF
--- a/initiatives/1641_Cloud_Native_AI_Scheduling_Challenges_Whitepaper/4_Resource_and_Infrastructure_Challenges_for_AI_Workloads.md
+++ b/initiatives/1641_Cloud_Native_AI_Scheduling_Challenges_Whitepaper/4_Resource_and_Infrastructure_Challenges_for_AI_Workloads.md
@@ -104,7 +104,7 @@ Hardware topology significantly impacts AI workload performance. Two different c
 * **Checkpointing:** Training jobs periodically save model state to storage. Checkpointing a large model can take minutes and requires high storage bandwidth. Frequent checkpointing (for fault tolerance) vs. infrequent checkpointing (for performance) is a tradeoff.  
 * **Model loading for inference:** Before serving requests, inference services must load model weights to GPU memory.  The time and method of loading depends on the scenario:  
   * Cold start: Loading from storage (local filesystems or cloud object storage (S3, GCS)) can take minutes for large models. Optimized streaming tools (such as Run:ai Model Streamer, Tensorizer, and fastsafetensors) reduce this to seconds by streaming weights directly into GPU memory.  
-  *   
+  * Distribution at scale: When many replicas start at once, each pulls the same weights independently, and the resulting thundering herd saturates registry or object store egress. Peer-to-peer distribution ([Dragonfly](https://github.com/dragonflyoss/dragonfly), CNCF Graduated) has nodes serve cached blocks to one another, reducing load on the origin as replica count grows.  
 * **Storage performance:** The MLCommons Storage benchmark measures storage system performance for ML workloads. Inadequate storage throughput can bottleneck the entire training pipeline, regardless of how many GPUs are available.
 
 ## Fault Tolerance and Elasticity

--- a/initiatives/1641_Cloud_Native_AI_Scheduling_Challenges_Whitepaper/5_Solutions_and_Practical_Guidance_for_AI_Workload_Scheduling.md
+++ b/initiatives/1641_Cloud_Native_AI_Scheduling_Challenges_Whitepaper/5_Solutions_and_Practical_Guidance_for_AI_Workload_Scheduling.md
@@ -93,6 +93,7 @@ These tools provide higher-level abstractions for AI workflows:
 
 ## Data and Storage Tools
 
+* [**Dragonfly**](https://github.com/dragonflyoss/dragonfly) (CNCF Graduated) accelerates distribution of container images and AI model artifacts through peer-to-peer networking, with `hf://` and `modelscope://` backends for model weights. Nodes serve cached content to one another, reducing registry load when many replicas start together.  
 * [**Fluid**](https://github.com/fluid-cloudnative/fluid) (CNCF Sbx) accelerates data access for AI workloads through dataset caching and data movement optimization. Reduces I/O bottlenecks that leave GPUs idle.  
 * [**HAMi**](https://github.com/Project-HAMi/HAMi) (Heterogeneous AI Computing Virtualization Middleware) enables flexible GPU sharing and partitioning across different GPU types.  
 * [**Kubeflow**](https://www.kubeflow.org/) (CNCF incubating project):  
@@ -130,7 +131,7 @@ A reference table that maps each challenge to the solutions that address it. All
 | Resource Heterogeneity | Node selectors, labels | All batch schedulers | \- | Both | Standard Kubernetes features usually sufficient |
 | GPU Sharing | DRA (GA, K8s 1.34+) | KAI | HAMi, KubeRay, Volcano | Both | MIG requires DRA or vendor tools |
 | Scalability | Cluster Autoscaler, Karpenter | Armada, KAI, KEDA, Kueue, Slinky, Volcano | interLink | Both | Large-scale scheduling is challenging |
-| I/O Bottlenecks | PersistentVolumes | \- | Fluid | Both | Storage and caching solutions |
+| I/O Bottlenecks | PersistentVolumes | \- | Dragonfly, Fluid | Both | Storage and caching solutions |
 | Fault Tolerance | \- | KAI, Slinky, Volcano (checkpoint support)  | Kubeflow (elastic training) | Training | Framework-dependent |
 | Elasticity | HPA, VPA | KAI, Slinky, Volcano | Kubeflow Trainer | Both | PyTorch Elastic, etc. |
 | Budget/Cost | \- | Limited support | Flyte (spot/interruptible tasks) | Both | Emerging area  |


### PR DESCRIPTION
Follow-up to #2164. Marlow asked me to send this straight to cncf/toc.

**Ch 4, I/O Bottlenecks:** the "Model loading for inference" list has an empty bullet right after "Cold start" looks like a placeholder that shipped blank. Filled it with the scale-out case: when a lot of replicas start at once they each pull the same weights independently and hammer the registry. The streaming tools in the cold start bullet help per-pod latency but don't do anything for that.

**Ch 5:** added Dragonfly (CNCF graduated) to Data and Storage Tools and to the I/O Bottlenecks row of the mapping table. Alphabetical in both, to match what's already there.

Happy to reword or make any changes.
