### PR TITLE
fix(ci): allow fork PR checkout in tags.yaml pull_request_target workflow

### DIFF
--- a/.github/workflows/tags_yaml_fork_pr_processing.yaml
+++ b/.github/workflows/tags_yaml_fork_pr_processing.yaml
@@ -27,6 +27,11 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }}  # Ensure branch checkout
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
+          # Safe here: the job never executes fork-provided code. It resets the
+          # working tree to origin/main before running generator/readme_app.go,
+          # only carrying over tags.yaml (data) from the fork. See:
+          # https://gh.io/securely-using-pull_request_target
+          allow-unsafe-pr-checkout: true
 
       - name: Set up Go
         uses: actions/setup-go@v4


### PR DESCRIPTION
## Summary
- `actions/checkout` now refuses by default to check out a fork PR's head ref inside a `pull_request_target` workflow (the "pwn request" guard).
- This blocks `tags_yaml_fork_pr_processing.yaml` for any fork PR that touches `tags.yaml`, e.g. #2274.
- This job is safe to opt in: it never executes fork-supplied code. After checkout it resets the working tree to `origin/main` and only carries over `tags.yaml` (data, not code) before running `generator/readme_app.go` from `main`.

## Fix
Add `allow-unsafe-pr-checkout: true` to the checkout step, per https://gh.io/securely-using-pull_request_target.

## Test plan
- [ ] Merge to `main`
- [ ] Confirm the `Generate README on Tags Change (Forked PR)` workflow runs successfully on #2274 after a re-run/push