### PR TITLE
Docs(scheduling-whitepaper): Add Pavan Madduri to contributors

### DIFF
--- a/initiatives/1641_Cloud_Native_AI_Scheduling_Challenges_Whitepaper/4_Resource_and_Infrastructure_Challenges_for_AI_Workloads.md
+++ b/initiatives/1641_Cloud_Native_AI_Scheduling_Challenges_Whitepaper/4_Resource_and_Infrastructure_Challenges_for_AI_Workloads.md
@@ -6,7 +6,7 @@ Abhishek Malvankar, Alexander Scammon, Andrey Velichkevich, Ekin Karabulut, Kevi
 
 **Contributors (in alphabetical order):**
 
-Adel Zaalouk, Andrew Shunichi Aikawa, Andrey Velichkevich, Boris Kurktchiev, Brian Redmond, Cathy Zhang, Claudia Misale, Joel Roberts, Johnu George, Josh Halley, Kay Yan, Malini Bhandaru, Michael Yao, Mike SHNg, Naadir Jeewa, Niki Manoledaki, Ricardo Aravena, Ronald Petty, Sachi Desai, Shravan Achar, Sudhanshu Prajapati, Victor Lu, Vijay Rodrigues
+Adel Zaalouk, Andrew Shunichi Aikawa, Andrey Velichkevich, Boris Kurktchiev, Brian Redmond, Cathy Zhang, Claudia Misale, Joel Roberts, Johnu George, Josh Halley, Kay Yan, Malini Bhandaru, Michael Yao, Mike SHNg, Naadir Jeewa, Niki Manoledaki, Pavan Madduri, Ricardo Aravena, Ronald Petty, Sachi Desai, Shravan Achar, Sudhanshu Prajapati, Victor Lu, Vijay Rodrigues
 
 # Series Introduction
 

--- a/initiatives/1641_Cloud_Native_AI_Scheduling_Challenges_Whitepaper/5_Solutions_and_Practical_Guidance_for_AI_Workload_Scheduling.md
+++ b/initiatives/1641_Cloud_Native_AI_Scheduling_Challenges_Whitepaper/5_Solutions_and_Practical_Guidance_for_AI_Workload_Scheduling.md
@@ -6,7 +6,7 @@ Abhishek Malvankar, Alexander Scammon, Andrey Velichkevich, Ekin Karabulut, Kevi
 
 **Contributors (in alphabetical order):**
 
-Adel Zaalouk, Andrew Shunichi Aikawa, Andrey Velichkevich, Boris Kurktchiev, Brian Redmond, Cathy Zhang, Claudia Misale, Joel Roberts, Johnu George, Josh Halley, Kay Yan, Malini Bhandaru, Michael Yao, Mike SHNg, Naadir Jeewa, Niki Manoledaki, Ricardo Aravena, Ronald Petty, Sachi Desai, Shravan Achar, Sudhanshu Prajapati, Victor Lu, Vijay Rodrigues
+Adel Zaalouk, Andrew Shunichi Aikawa, Andrey Velichkevich, Boris Kurktchiev, Brian Redmond, Cathy Zhang, Claudia Misale, Joel Roberts, Johnu George, Josh Halley, Kay Yan, Malini Bhandaru, Michael Yao, Mike SHNg, Naadir Jeewa, Niki Manoledaki, Pavan Madduri, Ricardo Aravena, Ronald Petty, Sachi Desai, Shravan Achar, Sudhanshu Prajapati, Victor Lu, Vijay Rodrigues
 
 # Series Introduction
 


### PR DESCRIPTION
Follow-up to #2272 (merged by @angellk): adding myself to the Contributors list of the two chapters I contributed to, per the existing convention.

The Contributors list appears to be series-wide across all five chapters. Happy to extend this to the remaining chapter files, or drop it entirely, if the bar for the contributors list is different.
